### PR TITLE
feat: implement allowance.rs — spender allowances with ledger-based expiration

### DIFF
--- a/veritixpay/contract/token/Makefile
+++ b/veritixpay/contract/token/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l ../../target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/veritixpay/contract/token/src/allowance.rs
+++ b/veritixpay/contract/token/src/allowance.rs
@@ -1,0 +1,72 @@
+use crate::storage_types::{AllowanceDataKey, AllowanceValue, DataKey};
+use soroban_sdk::{Address, Env};
+
+pub fn read_allowance(e: &Env, from: Address, spender: Address) -> AllowanceValue {
+    let key = DataKey::Allowance(AllowanceDataKey {
+        from: from.clone(),
+        spender: spender.clone(),
+    });
+    
+    if let Some(allowance) = e.storage().persistent().get::<DataKey, AllowanceValue>(&key) {
+        if allowance.expiration_ledger < e.ledger().sequence() {
+            AllowanceValue {
+                amount: 0,
+                expiration_ledger: allowance.expiration_ledger,
+            }
+        } else {
+            allowance
+        }
+    } else {
+        AllowanceValue {
+            amount: 0,
+            expiration_ledger: 0,
+        }
+    }
+}
+
+pub fn write_allowance(
+    e: &Env,
+    from: Address,
+    spender: Address,
+    amount: i128,
+    expiration_ledger: u32,
+) {
+    if expiration_ledger < e.ledger().sequence() {
+        panic!("expiration ledger is in the past");
+    }
+
+    let key = DataKey::Allowance(AllowanceDataKey {
+        from: from.clone(),
+        spender: spender.clone(),
+    });
+
+    if amount == 0 {
+        e.storage().persistent().remove(&key);
+    } else {
+        let allowance = AllowanceValue {
+            amount,
+            expiration_ledger,
+        };
+        e.storage().persistent().set(&key, &allowance);
+    }
+}
+
+pub fn spend_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
+    let allowance = read_allowance(e, from.clone(), spender.clone());
+    
+    if allowance.expiration_ledger < e.ledger().sequence() {
+        panic!("allowance is expired");
+    }
+    
+    if allowance.amount < amount {
+        panic!("insufficient allowance");
+    }
+    
+    write_allowance(
+        e,
+        from,
+        spender,
+        allowance.amount - amount,
+        allowance.expiration_ledger,
+    );
+}

--- a/veritixpay/contract/token/src/lib.rs
+++ b/veritixpay/contract/token/src/lib.rs
@@ -1,6 +1,9 @@
+#![no_std]
+
 // Veritix Pay — Smart contract logic coming soon.
 // Contributors: see CONTRIBUTING.md for how to get started.
 
 pub mod storage_types;
 pub mod admin;
 pub mod metadata;
+pub mod allowance;


### PR DESCRIPTION
This PR closes #51.

 - Uses DataKey::Allowance(AllowanceDataKey { from, spender })
 - Expiry is correctly enforced in spend_allowance
 - Zero-amount allowance is removed, not stored
 - Past expiration ledger on write panics
 - pub mod allowance; declared in lib.rs
 - make build passes