### PR TITLE
fix: remove freeze check from receive_balance() to unblock escrow flows

### DIFF
--- a/veritixpay/contract/token/src/balance.rs
+++ b/veritixpay/contract/token/src/balance.rs
@@ -1,5 +1,4 @@
 use crate::storage_types::{DataKey, BALANCE_BUMP_AMOUNT, BALANCE_LIFETIME_THRESHOLD};
-use crate::validation::require_not_frozen_account;
 use soroban_sdk::{Address, Env};
 
 /// Returns the balance for an address, or 0 if not set
@@ -17,8 +16,6 @@ pub fn read_balance(e: &Env, addr: Address) -> i128 {
 
 /// Adds amount to address balance
 pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
-    require_not_frozen_account(e, &addr);
-
     let key = DataKey::Balance(addr.clone());
     let current_balance = read_balance(e, addr); // TTL is extended here
     let new_balance = current_balance + amount;

--- a/veritixpay/contract/token/src/test.rs
+++ b/veritixpay/contract/token/src/test.rs
@@ -406,3 +406,25 @@ fn test_clawback_unauthorized_panics() {
 
     client.clawback(&user, &user, &300i128);
 }
+
+#[test]
+fn test_frozen_account_can_receive_from_escrow_release() {
+    let (env, admin, user) = setup();
+    env.mock_all_auths();
+    let client = create_client(&env);
+    let beneficiary = Address::generate(&env);
+
+    initialize_client(&client, &env, &admin, 7);
+    client.mint(&admin, &user, &1_000i128);
+
+    // Freeze the beneficiary — they should still be able to receive escrowed funds.
+    client.freeze(&beneficiary);
+    assert!(client.is_frozen(&beneficiary));
+
+    let escrow_id = client.create_escrow(&user, &beneficiary, &1_000i128);
+
+    // Release escrow to the frozen beneficiary — must not panic.
+    client.release_escrow(&user, &escrow_id);
+
+    assert_eq!(client.balance(&beneficiary), 1_000i128);
+}


### PR DESCRIPTION
## Summary

`receive_balance()` called `require_not_frozen_account` before crediting any balance. The escrow, splitter, and dispute modules all route funds through the contract address (`e.current_contract_address()`). If an admin ever froze the contract address itself, all escrow creates, split creates, and dispute resolutions would permanently panic — locking all funds with no recovery path.

Freezing should only block **outbound** transfers and approvals, not inbound credits.

## Fix

- Removed `require_not_frozen_account` from `receive_balance()`
- Removed the now-unused `use crate::validation::require_not_frozen_account` import
- The freeze check remains enforced in `contract.rs` for `transfer` and `transfer_from`

## Test added

`test_frozen_account_can_receive_from_escrow_release` in `src/test.rs`:
- Freezes the beneficiary
- Creates an escrow from the depositor to the frozen beneficiary
- Releases the escrow — confirms no panic and beneficiary balance is credited

## Files changed
- `veritixpay/contract/token/src/balance.rs`
- `veritixpay/contract/token/src/test.rs`

Closes #144