### PR TITLE
fix: add explicit balance check in execute_recurring() with contextual panic message

### DIFF
--- a/veritixpay/contract/token/src/recurring.rs
+++ b/veritixpay/contract/token/src/recurring.rs
@@ -71,6 +71,14 @@ pub fn execute_recurring(e: &Env, recurring_id: u32) {
         panic!("interval has not elapsed");
     }
 
+    let payer_balance = crate::balance::read_balance(e, record.payer.clone());
+    if payer_balance < record.amount {
+        panic!(
+            "InsufficientBalance: payer has insufficient balance for recurring payment {}",
+            recurring_id
+        );
+    }
+
     spend_balance(e, record.payer.clone(), record.amount);
     receive_balance(e, record.payee.clone(), record.amount);
 

--- a/veritixpay/contract/token/src/recurring_test.rs
+++ b/veritixpay/contract/token/src/recurring_test.rs
@@ -114,6 +114,21 @@ mod recurring_tests {
     }
 
     #[test]
+    #[should_panic(expected = "InsufficientBalance")]
+    fn test_execute_recurring_insufficient_balance_panics() {
+        let e = setup_env();
+        let contract_id = e.register_contract(None, VeritixToken);
+        // Fund payer with less than the recurring amount.
+        let (payer, _payee, id) = fund_and_setup(&e, &contract_id, 500, 100);
+        e.as_contract(&contract_id, || {
+            // Drain the payer balance so they can no longer cover the charge.
+            crate::balance::spend_balance(&e, payer.clone(), 500);
+            e.ledger().set_sequence_number(e.ledger().sequence() + 101);
+            execute_recurring(&e, id);
+        });
+    }
+
+    #[test]
     fn test_multiple_executions() {
         let e = setup_env();
         let contract_id = e.register_contract(None, VeritixToken);


### PR DESCRIPTION
## Summary

`execute_recurring()` called `spend_balance()` without first verifying the payer has sufficient funds. When the payer runs out of funds, the contract panicked with a generic message:
```
"insufficient balance: attempted to spend X but only Y available"
```
This gives no context about which recurring payment failed, making it impossible for callers to distinguish this panic from any other balance error.

## Fix

Before calling `spend_balance`, read the payer balance and check it is sufficient. If not, panic with a message that includes the recurring ID:
```rust
"InsufficientBalance: payer has insufficient balance for recurring payment {id}"
```

## Test added

`test_execute_recurring_insufficient_balance_panics` in `src/recurring_test.rs`:
- Sets up a recurring payment for 500 tokens
- Drains the payer balance to 0
- Advances the ledger past the interval
- Confirms the call panics with `"InsufficientBalance"`

## Files changed
- `veritixpay/contract/token/src/recurring.rs`
- `veritixpay/contract/token/src/recurring_test.rs`

Closes #145