### PR TITLE
fix: resolve issues #146, #147, #148, #149

### DIFF
--- a/veritixpay/contract/token/src/admin.rs
+++ b/veritixpay/contract/token/src/admin.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{symbol_short, Address, Env};
 
 use crate::storage_types::DataKey;
 
@@ -30,4 +30,8 @@ pub fn transfer_admin(e: &Env, new_admin: Address) {
     let current_admin = read_admin(e);
     current_admin.require_auth();
     write_admin(e, &new_admin);
+    e.events().publish(
+        (symbol_short!("admin_set"), current_admin),
+        new_admin,
+    );
 }

--- a/veritixpay/contract/token/src/contract.rs
+++ b/veritixpay/contract/token/src/contract.rs
@@ -186,8 +186,8 @@ impl VeritixToken {
 
     // --- Escrow ---
 
-    pub fn create_escrow(e: Env, depositor: Address, beneficiary: Address, amount: i128) -> u32 {
-        escrow_create(&e, depositor, beneficiary, amount)
+    pub fn create_escrow(e: Env, depositor: Address, beneficiary: Address, amount: i128, expiry_ledger: u32) -> u32 {
+        escrow_create(&e, depositor, beneficiary, amount, expiry_ledger)
     }
 
     pub fn release_escrow(e: Env, caller: Address, escrow_id: u32) {

--- a/veritixpay/contract/token/src/dispute_test.rs
+++ b/veritixpay/contract/token/src/dispute_test.rs
@@ -18,7 +18,7 @@ fn setup_escrow(e: &Env, contract_id: &Address) -> (Address, Address, u32) {
     let mut escrow_id = 0u32;
     e.as_contract(contract_id, || {
         crate::balance::receive_balance(e, depositor.clone(), amount);
-        escrow_id = create_escrow(e, depositor.clone(), beneficiary.clone(), amount);
+        escrow_id = create_escrow(e, depositor.clone(), beneficiary.clone(), amount, 1000);
     });
     (depositor, beneficiary, escrow_id)
 }

--- a/veritixpay/contract/token/src/escrow.rs
+++ b/veritixpay/contract/token/src/escrow.rs
@@ -2,7 +2,7 @@ use crate::balance::{receive_balance, spend_balance};
 use crate::storage_types::{
     increment_counter, read_persistent_record, write_persistent_record, DataKey,
 };
-use crate::validation::require_positive_amount;
+use crate::validation::{require_current_or_future_ledger, require_positive_amount};
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 #[contracttype]
@@ -14,12 +14,20 @@ pub struct EscrowRecord {
     pub amount: i128,
     pub released: bool,
     pub refunded: bool,
+    pub expiry_ledger: u32,
 }
 
 // Lock funds from depositor into escrow. The contract address itself holds the
 // escrowed balance until the record is released or refunded. Returns the escrow ID.
-pub fn create_escrow(e: &Env, depositor: Address, beneficiary: Address, amount: i128) -> u32 {
+pub fn create_escrow(
+    e: &Env,
+    depositor: Address,
+    beneficiary: Address,
+    amount: i128,
+    expiry_ledger: u32,
+) -> u32 {
     require_positive_amount(amount);
+    require_current_or_future_ledger(e.ledger().sequence(), expiry_ledger);
 
     // Auth: depositor must authorize locking funds
     depositor.require_auth();
@@ -39,6 +47,7 @@ pub fn create_escrow(e: &Env, depositor: Address, beneficiary: Address, amount: 
         amount,
         released: false,
         refunded: false,
+        expiry_ledger,
     };
     write_persistent_record(e, &DataKey::Escrow(count), &record);
 
@@ -100,8 +109,9 @@ pub fn try_refund_escrow(e: &Env, caller: Address, escrow_id: u32) -> Result<(),
 
     let mut escrow = try_get_escrow(e, escrow_id)?;
 
-    // Authorization: only the original depositor can refund
-    if escrow.depositor != caller {
+    // Authorization: only the original depositor can refund, unless the escrow has expired
+    let expired = e.ledger().sequence() > escrow.expiry_ledger;
+    if escrow.depositor != caller && !expired {
         return Err("not depositor");
     }
 

--- a/veritixpay/contract/token/src/escrow_test.rs
+++ b/veritixpay/contract/token/src/escrow_test.rs
@@ -37,7 +37,7 @@ fn test_create_escrow_stores_record() {
         // Pre-fund depositor so spend_balance in create_escrow succeeds.
         crate::balance::receive_balance(&e, depositor.clone(), amount);
 
-        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount);
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
         let record = get_escrow(&e, escrow_id);
 
         assert_eq!(record.id, escrow_id);
@@ -63,7 +63,7 @@ fn test_release_escrow_happy_path() {
     let mut escrow_id: u32 = 0;
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor.clone(), amount);
-        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount);
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
     });
 
     // Second call: release the escrow and check balances.
@@ -105,7 +105,7 @@ fn test_refund_escrow_happy_path() {
     let mut escrow_id: u32 = 0;
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor.clone(), amount);
-        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount);
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
     });
 
     // Second call: refund the escrow and check balances.
@@ -147,7 +147,7 @@ fn test_escrow_create_and_release_preserve_supply_invariant() {
             &[depositor.clone(), beneficiary.clone(), e.current_contract_address()],
         );
 
-        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount);
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
         assert_supply_matches_balances(
             &e,
             &[depositor.clone(), beneficiary.clone(), e.current_contract_address()],
@@ -180,7 +180,7 @@ fn test_escrow_create_and_refund_preserve_supply_invariant() {
             &[depositor.clone(), beneficiary.clone(), e.current_contract_address()],
         );
 
-        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount);
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
         assert_supply_matches_balances(
             &e,
             &[depositor.clone(), beneficiary.clone(), e.current_contract_address()],
@@ -206,14 +206,14 @@ fn test_create_escrow_increments_counter() {
     let depositor_one = Address::generate(&e);
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor_one.clone(), amount);
-        let escrow_id = create_escrow(&e, depositor_one.clone(), beneficiary.clone(), amount);
+        let escrow_id = create_escrow(&e, depositor_one.clone(), beneficiary.clone(), amount, 1000);
         assert_eq!(escrow_id, 1);
     });
 
     let depositor_two = Address::generate(&e);
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor_two.clone(), amount);
-        let escrow_id = create_escrow(&e, depositor_two.clone(), beneficiary.clone(), amount);
+        let escrow_id = create_escrow(&e, depositor_two.clone(), beneficiary.clone(), amount, 1000);
         assert_eq!(escrow_id, 2);
     });
 
@@ -240,7 +240,7 @@ fn test_escrow_count_getter_reflects_creations() {
     let depositor_one = Address::generate(&e);
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor_one.clone(), amount);
-        let _ = VeritixToken::create_escrow(e.clone(), depositor_one.clone(), beneficiary.clone(), amount);
+        let _ = VeritixToken::create_escrow(e.clone(), depositor_one.clone(), beneficiary.clone(), amount, 1000);
         assert_eq!(VeritixToken::escrow_count(e.clone()), 1);
     });
 
@@ -248,7 +248,7 @@ fn test_escrow_count_getter_reflects_creations() {
     let depositor_two = Address::generate(&e);
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor_two.clone(), amount);
-        let _ = VeritixToken::create_escrow(e.clone(), depositor_two.clone(), beneficiary.clone(), amount);
+        let _ = VeritixToken::create_escrow(e.clone(), depositor_two.clone(), beneficiary.clone(), amount, 1000);
         assert_eq!(VeritixToken::escrow_count(e.clone()), 2);
     });
 }
@@ -292,7 +292,7 @@ fn test_refund_missing_id_returns_not_found_error() {
 }
 
 #[test]
-#[ignore] // Disabled: panics abort in this test configuration
+#[should_panic]
 fn test_release_unauthorized_panics() {
     let e = setup_env();
     let depositor = Address::generate(&e);
@@ -302,14 +302,14 @@ fn test_release_unauthorized_panics() {
 
     crate::balance::receive_balance(&e, depositor.clone(), amount);
 
-    let escrow_id = create_escrow(&e, depositor, beneficiary, amount);
+    let escrow_id = create_escrow(&e, depositor, beneficiary, amount, 1000);
 
     // Hacker (not beneficiary) tries to release.
     release_escrow(&e, hacker, escrow_id);
 }
 
 #[test]
-#[ignore] // Disabled: panics abort in this test configuration
+#[should_panic]
 fn test_refund_unauthorized_panics() {
     let e = setup_env();
     let depositor = Address::generate(&e);
@@ -318,14 +318,14 @@ fn test_refund_unauthorized_panics() {
 
     crate::balance::receive_balance(&e, depositor.clone(), amount);
 
-    let escrow_id = create_escrow(&e, depositor, beneficiary.clone(), amount);
+    let escrow_id = create_escrow(&e, depositor, beneficiary.clone(), amount, 1000);
 
     // Beneficiary (not depositor) tries to refund.
     refund_escrow(&e, beneficiary, escrow_id);
 }
 
 #[test]
-#[ignore] // Disabled: panics abort in this test configuration
+#[should_panic]
 fn test_double_release_panics() {
     let e = setup_env();
     let depositor = Address::generate(&e);
@@ -334,7 +334,7 @@ fn test_double_release_panics() {
 
     crate::balance::receive_balance(&e, depositor.clone(), amount);
 
-    let escrow_id = create_escrow(&e, depositor, beneficiary.clone(), amount);
+    let escrow_id = create_escrow(&e, depositor, beneficiary.clone(), amount, 1000);
 
     release_escrow(&e, beneficiary.clone(), escrow_id);
     // Second release should panic.
@@ -342,7 +342,7 @@ fn test_double_release_panics() {
 }
 
 #[test]
-#[ignore] // Disabled: panics abort in this test configuration
+#[should_panic]
 fn test_double_refund_panics() {
     let e = setup_env();
     let depositor = Address::generate(&e);
@@ -351,7 +351,7 @@ fn test_double_refund_panics() {
 
     crate::balance::receive_balance(&e, depositor.clone(), amount);
 
-    let escrow_id = create_escrow(&e, depositor.clone(), beneficiary, amount);
+    let escrow_id = create_escrow(&e, depositor.clone(), beneficiary, amount, 1000);
 
     refund_escrow(&e, depositor.clone(), escrow_id);
     // Second refund should panic.
@@ -359,7 +359,7 @@ fn test_double_refund_panics() {
 }
 
 #[test]
-#[ignore] // Disabled: panics abort in this test configuration
+#[should_panic]
 fn test_release_after_refund_panics() {
     let e = setup_env();
     let depositor = Address::generate(&e);
@@ -368,7 +368,7 @@ fn test_release_after_refund_panics() {
 
     crate::balance::receive_balance(&e, depositor.clone(), amount);
 
-    let escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount);
+    let escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
 
     refund_escrow(&e, depositor, escrow_id);
     // Any attempt to release after refund should panic.

--- a/veritixpay/contract/token/src/storage_types.rs
+++ b/veritixpay/contract/token/src/storage_types.rs
@@ -40,10 +40,6 @@ pub enum DataKey {
     // Tracks the active dispute ID for a given escrow (None = no open dispute).
     EscrowDispute(u32),
 
-    // Reserved for future multi-escrow support.
-    MultiEscrowCount,
-    MultiEscrow(u32),
-
     // Stores per-address freeze status.
     Freeze(Address),
 }

--- a/veritixpay/contract/token/src/test.rs
+++ b/veritixpay/contract/token/src/test.rs
@@ -51,7 +51,7 @@ fn test_initialize() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_initialize_twice_panics() {
     let (env, admin, _user) = setup();
     env.mock_all_auths();
@@ -62,7 +62,7 @@ fn test_initialize_twice_panics() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_initialize_rejects_decimal_above_eighteen() {
     let (env, admin, _user) = setup();
     env.mock_all_auths();
@@ -72,7 +72,7 @@ fn test_initialize_rejects_decimal_above_eighteen() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_initialize_rejects_empty_name() {
     let (env, admin, _user) = setup();
     env.mock_all_auths();
@@ -87,7 +87,7 @@ fn test_initialize_rejects_empty_name() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_initialize_rejects_empty_symbol() {
     let (env, admin, _user) = setup();
     env.mock_all_auths();
@@ -102,7 +102,7 @@ fn test_initialize_rejects_empty_symbol() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_initialize_requires_admin_authorization() {
     let (env, admin, _user) = setup();
     let client = create_client(&env);
@@ -124,7 +124,7 @@ fn test_mint() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_mint_unauthorized_panics() {
     let (env, admin, user) = setup();
     env.mock_all_auths();
@@ -152,7 +152,7 @@ fn test_burn() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_burn_insufficient_panics() {
     let (env, admin, user) = setup();
     env.mock_all_auths();
@@ -181,7 +181,7 @@ fn test_transfer() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_transfer_insufficient_balance_panics() {
     let (env, admin, user) = setup();
     env.mock_all_auths();
@@ -262,7 +262,7 @@ fn test_allowance_expiration_equal_current_ledger_is_valid_for_current_ledger() 
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_expired_allowance_panics() {
     let (env, admin, user) = setup();
     env.mock_all_auths();
@@ -394,7 +394,7 @@ fn test_core_token_operations_preserve_supply_invariant() {
 }
 
 #[test]
-#[ignore = "Panics abort in this Soroban test configuration"]
+#[should_panic]
 fn test_clawback_unauthorized_panics() {
     let (env, admin, user) = setup();
     env.mock_all_auths();
@@ -421,7 +421,7 @@ fn test_frozen_account_can_receive_from_escrow_release() {
     client.freeze(&beneficiary);
     assert!(client.is_frozen(&beneficiary));
 
-    let escrow_id = client.create_escrow(&user, &beneficiary, &1_000i128);
+    let escrow_id = client.create_escrow(&user, &beneficiary, &1_000i128, &1000u32);
 
     // Release escrow to the frozen beneficiary — must not panic.
     client.release_escrow(&user, &escrow_id);


### PR DESCRIPTION
#146 - Replace #[ignore] with #[should_panic] on all ignored panic tests in test.rs (8 tests) and escrow_test.rs (5 tests). The #[ignore] workaround was unnecessary; other test files already use #[should_panic] successfully.

#147 - Emit admin_set event in transfer_admin() after write_admin so admin rotation is observable on-chain, consistent with all other state-changing operations (mint, burn, transfer, freeze, clawback).

#148 - Remove dead MultiEscrowCount and MultiEscrow DataKey variants from storage_types.rs. These had no corresponding module and would pollute the deployed contract ABI surface unnecessarily.

#149 - Add expiry_ledger: u32 field to EscrowRecord. create_escrow now accepts and validates expiry_ledger (must be >= current ledger sequence). refund_escrow now allows any caller to trigger a refund once the escrow has expired, preventing depositor funds from being locked indefinitely. Updated contract.rs, escrow_test.rs, and dispute_test.rs accordingly.

Closes #146
Closes #147
Closes #148
Closes #149