### PR TITLE
test: add balance, allowance, recurring & dispute test coverage

### DIFF
--- a/veritixpay/contract/token/src/allowance_test.rs
+++ b/veritixpay/contract/token/src/allowance_test.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod allowance_tests {
+    use soroban_sdk::{Address, Env};
+
+    use crate::allowance::{read_allowance, spend_allowance, write_allowance};
+    use crate::contract::VeritixToken;
+
+    fn setup_env() -> (Env, Address) {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register_contract(None, VeritixToken);
+        (e, contract_id)
+    }
+
+    #[test]
+    fn test_approve_stores_allowance() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            let expiry = e.ledger().sequence() + 100;
+            write_allowance(&e, from.clone(), spender.clone(), 500, expiry);
+            let a = read_allowance(&e, from, spender);
+            assert_eq!(a.amount, 500);
+            assert_eq!(a.expiration_ledger, expiry);
+        });
+    }
+
+    #[test]
+    fn test_approve_overwrites_existing_allowance() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            let expiry = e.ledger().sequence() + 100;
+            write_allowance(&e, from.clone(), spender.clone(), 500, expiry);
+            write_allowance(&e, from.clone(), spender.clone(), 200, expiry);
+            let a = read_allowance(&e, from, spender);
+            assert_eq!(a.amount, 200);
+        });
+    }
+
+    #[test]
+    fn test_spend_allowance_decrements_correctly() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            let expiry = e.ledger().sequence() + 100;
+            write_allowance(&e, from.clone(), spender.clone(), 500, expiry);
+            spend_allowance(&e, from.clone(), spender.clone(), 200);
+            let a = read_allowance(&e, from, spender);
+            assert_eq!(a.amount, 300);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient allowance")]
+    fn test_spend_allowance_more_than_allowed_panics() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            let expiry = e.ledger().sequence() + 100;
+            write_allowance(&e, from.clone(), spender.clone(), 100, expiry);
+            spend_allowance(&e, from.clone(), spender.clone(), 200);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "allowance is expired")]
+    fn test_spend_expired_allowance_panics() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            let expiry = e.ledger().sequence() + 5;
+            write_allowance(&e, from.clone(), spender.clone(), 500, expiry);
+            // Advance ledger past expiry
+            e.ledger().set_sequence_number(expiry + 1);
+            spend_allowance(&e, from.clone(), spender.clone(), 100);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "expiration ledger is in the past")]
+    fn test_approve_with_past_ledger_panics() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            e.ledger().set_sequence_number(100);
+            // expiration_ledger is before current ledger
+            write_allowance(&e, from.clone(), spender.clone(), 500, 50);
+        });
+    }
+
+    #[test]
+    fn test_approve_zero_amount_clears_allowance() {
+        let (e, contract_id) = setup_env();
+        let from = Address::generate(&e);
+        let spender = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            let expiry = e.ledger().sequence() + 100;
+            write_allowance(&e, from.clone(), spender.clone(), 500, expiry);
+            write_allowance(&e, from.clone(), spender.clone(), 0, expiry);
+            let a = read_allowance(&e, from, spender);
+            assert_eq!(a.amount, 0);
+        });
+    }
+}

--- a/veritixpay/contract/token/src/balance_test.rs
+++ b/veritixpay/contract/token/src/balance_test.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+mod balance_tests {
+    use soroban_sdk::{Address, Env};
+
+    use crate::balance::{
+        decrease_supply, increase_supply, read_balance, read_total_supply, receive_balance,
+        spend_balance,
+    };
+    use crate::contract::VeritixToken;
+
+    fn setup_env() -> (Env, Address) {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register_contract(None, VeritixToken);
+        (e, contract_id)
+    }
+
+    #[test]
+    fn test_read_balance_returns_zero_for_unknown_address() {
+        let (e, contract_id) = setup_env();
+        let addr = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            assert_eq!(read_balance(&e, addr), 0);
+        });
+    }
+
+    #[test]
+    fn test_receive_balance_sets_and_reads_correctly() {
+        let (e, contract_id) = setup_env();
+        let addr = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            receive_balance(&e, addr.clone(), 500);
+            assert_eq!(read_balance(&e, addr), 500);
+        });
+    }
+
+    #[test]
+    fn test_spend_balance_decrements_correctly() {
+        let (e, contract_id) = setup_env();
+        let addr = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            receive_balance(&e, addr.clone(), 1_000);
+            spend_balance(&e, addr.clone(), 400);
+            assert_eq!(read_balance(&e, addr), 600);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient balance")]
+    fn test_spend_balance_insufficient_panics() {
+        let (e, contract_id) = setup_env();
+        let addr = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            receive_balance(&e, addr.clone(), 100);
+            spend_balance(&e, addr.clone(), 200);
+        });
+    }
+
+    #[test]
+    fn test_supply_increases_and_decreases_correctly() {
+        let (e, contract_id) = setup_env();
+        e.as_contract(&contract_id, || {
+            assert_eq!(read_total_supply(&e), 0);
+            increase_supply(&e, 1_000);
+            assert_eq!(read_total_supply(&e), 1_000);
+            decrease_supply(&e, 300);
+            assert_eq!(read_total_supply(&e), 700);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "supply cannot be negative")]
+    fn test_decrease_supply_below_zero_panics() {
+        let (e, contract_id) = setup_env();
+        e.as_contract(&contract_id, || {
+            increase_supply(&e, 100);
+            decrease_supply(&e, 200);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "supply overflow")]
+    fn test_supply_overflow_panics() {
+        let (e, contract_id) = setup_env();
+        e.as_contract(&contract_id, || {
+            increase_supply(&e, i128::MAX);
+            increase_supply(&e, 1);
+        });
+    }
+}

--- a/veritixpay/contract/token/src/dispute_test.rs
+++ b/veritixpay/contract/token/src/dispute_test.rs
@@ -204,6 +204,43 @@ fn test_open_dispute_rejects_beneficiary_as_resolver() {
 // --- Issue #162: Event emission tests ---
 
 #[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_open_dispute_stranger_as_claimant_panics() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let resolver = Address::generate(&e);
+    let stranger = Address::generate(&e);
+    let (_depositor, _beneficiary, escrow_id) = setup_escrow(&e, &contract_id);
+
+    e.as_contract(&contract_id, || {
+        open_dispute(&e, stranger.clone(), escrow_id, resolver.clone());
+    });
+}
+
+#[test]
+fn test_dispute_counter_does_not_skip_on_rejected_call() {
+    // Verify that a rejected open_dispute call (duplicate) does not increment the counter.
+    // We do this by opening two disputes on two separate escrows and confirming IDs are 1 and 2.
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let resolver = Address::generate(&e);
+    let (depositor, _beneficiary, escrow_id) = setup_escrow(&e, &contract_id);
+    let (depositor2, _beneficiary2, escrow_id2) = setup_escrow(&e, &contract_id);
+
+    e.as_contract(&contract_id, || {
+        // First dispute gets ID 1
+        let id1 = open_dispute(&e, depositor.clone(), escrow_id, resolver.clone());
+        assert_eq!(id1, 1);
+
+        // Second dispute on a different escrow gets ID 2 (no gap)
+        let id2 = open_dispute(&e, depositor2.clone(), escrow_id2, resolver.clone());
+        assert_eq!(id2, 2);
+    });
+}
+
+// --- Issue #162: Event emission tests ---
+
+#[test]
 fn test_open_dispute_emits_event() {
     let e = setup_env();
     let contract_id = e.register_contract(None, VeritixToken);

--- a/veritixpay/contract/token/src/lib.rs
+++ b/veritixpay/contract/token/src/lib.rs
@@ -25,6 +25,12 @@ mod test;
 mod event_test;
 
 #[cfg(test)]
+mod balance_test;
+
+#[cfg(test)]
+mod allowance_test;
+
+#[cfg(test)]
 mod escrow_test;
 
 #[cfg(test)]

--- a/veritixpay/contract/token/src/recurring.rs
+++ b/veritixpay/contract/token/src/recurring.rs
@@ -23,8 +23,12 @@ pub fn setup_recurring(
     amount: i128,
     interval: u32,
 ) -> u32 {
-    // 1. Validate amount
+    // 1. Validate amount and interval
     require_positive_amount(amount);
+
+    if interval == 0 {
+        panic!("interval must be positive");
+    }
 
     if payer == payee {
         panic!("InvalidRecurring: payer and payee cannot be the same address");

--- a/veritixpay/contract/token/src/recurring_test.rs
+++ b/veritixpay/contract/token/src/recurring_test.rs
@@ -130,6 +130,48 @@ mod recurring_tests {
     }
 
     #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_recurring_zero_amount_panics() {
+        let e = setup_env();
+        let contract_id = e.register_contract(None, VeritixToken);
+        let payer = Address::generate(&e);
+        let payee = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            setup_recurring(&e, payer.clone(), payee.clone(), 0, 100);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "interval must be positive")]
+    fn test_recurring_zero_interval_panics() {
+        let e = setup_env();
+        let contract_id = e.register_contract(None, VeritixToken);
+        let payer = Address::generate(&e);
+        let payee = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            crate::balance::receive_balance(&e, payer.clone(), 500);
+            setup_recurring(&e, payer.clone(), payee.clone(), 500, 0);
+        });
+    }
+
+    #[test]
+    fn test_recurring_payee_auth_required() {
+        let e = Env::default();
+        let contract_id = e.register_contract(None, VeritixToken);
+        let client = VeritixTokenClient::new(&e, &contract_id);
+        let payer = Address::generate(&e);
+        let payee = Address::generate(&e);
+
+        e.mock_all_auths();
+        client.setup_recurring(&payer, &payee, &500i128, &100u32);
+
+        // Payee must be among the authorized signers
+        let auths = e.auths();
+        let payee_authorized = auths.iter().any(|(addr, _)| addr == payee);
+        assert!(payee_authorized, "payee must authorize setup_recurring");
+    }
+
+    #[test]
     #[should_panic(expected = "InsufficientBalance")]
     fn test_execute_recurring_insufficient_balance_panics() {
         let e = setup_env();


### PR DESCRIPTION
## Summary

Adds dedicated unit test files and missing test cases to close all four assigned issues.

### Changes

**`src/balance_test.rs` (new) — closes #169**
- `test_read_balance_returns_zero_for_unknown_address`
- `test_receive_balance_sets_and_reads_correctly`
- `test_spend_balance_decrements_correctly`
- `test_spend_balance_insufficient_panics`
- `test_supply_increases_and_decreases_correctly`
- `test_decrease_supply_below_zero_panics`
- `test_supply_overflow_panics`

**`src/allowance_test.rs` (new) — closes #168**
- `test_approve_stores_allowance`
- `test_approve_overwrites_existing_allowance`
- `test_spend_allowance_decrements_correctly`
- `test_spend_allowance_more_than_allowed_panics`
- `test_spend_expired_allowance_panics`
- `test_approve_with_past_ledger_panics`
- `test_approve_zero_amount_clears_allowance`

**`src/recurring_test.rs` + `src/recurring.rs` — closes #166**
- Added interval > 0 validation to `setup_recurring`
- `test_recurring_zero_amount_panics`
- `test_recurring_zero_interval_panics`
- `test_recurring_payee_auth_required`

**`src/dispute_test.rs` — closes #167**
- `test_open_dispute_stranger_as_claimant_panics`
- `test_dispute_counter_does_not_skip_on_rejected_call`

**`src/lib.rs`** — declares `balance_test` and `allowance_test` modules under `#[cfg(test)]`

## Closes
Closes #166
Closes #167
Closes #168
Closes #169