### PR TITLE
fix: checked arithmetic, TTL management, escrow entrypoints, and validation

### DIFF
--- a/veritixpay/contract/token/src/admin.rs
+++ b/veritixpay/contract/token/src/admin.rs
@@ -1,14 +1,16 @@
 use soroban_sdk::{symbol_short, Address, Env};
 
-use crate::storage_types::DataKey;
+use crate::storage_types::{bump_instance, DataKey};
 
 // --- Core admin storage helpers ---
 
 pub fn read_admin(e: &Env) -> Address {
+    bump_instance(e);
     e.storage().instance().get(&DataKey::Admin).unwrap()
 }
 
 pub fn write_admin(e: &Env, id: &Address) {
+    bump_instance(e);
     e.storage().instance().set(&DataKey::Admin, id);
 }
 

--- a/veritixpay/contract/token/src/balance.rs
+++ b/veritixpay/contract/token/src/balance.rs
@@ -1,4 +1,4 @@
-use crate::storage_types::{DataKey, BALANCE_BUMP_AMOUNT, BALANCE_LIFETIME_THRESHOLD};
+use crate::storage_types::{bump_instance, DataKey, BALANCE_BUMP_AMOUNT, BALANCE_LIFETIME_THRESHOLD};
 use soroban_sdk::{Address, Env};
 
 /// Returns the balance for an address, or 0 if not set
@@ -14,15 +14,21 @@ pub fn read_balance(e: &Env, addr: Address) -> i128 {
     }
 }
 
-/// Adds amount to address balance
+/// Adds amount to address balance — panics on overflow
 pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
     let key = DataKey::Balance(addr.clone());
     let current_balance = read_balance(e, addr); // TTL is extended here
-    let new_balance = current_balance + amount;
+    let new_balance = current_balance
+        .checked_add(amount)
+        .expect("balance overflow");
 
     e.storage().persistent().set(&key, &new_balance);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, BALANCE_LIFETIME_THRESHOLD, BALANCE_BUMP_AMOUNT);
 }
-/// Subtracts amount from address balance — panics if insufficient
+
+/// Subtracts amount from address balance — panics if insufficient or underflow
 pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
     let key = DataKey::Balance(addr.clone());
     let current_balance = read_balance(e, addr);
@@ -34,7 +40,9 @@ pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
         );
     }
 
-    let new_balance = current_balance - amount;
+    let new_balance = current_balance
+        .checked_sub(amount)
+        .expect("balance underflow");
 
     let storage = e.storage().persistent();
     storage.set(&key, &new_balance);
@@ -45,6 +53,7 @@ pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
 // (Make sure to import DataKey if not already imported)
 
 pub fn read_total_supply(e: &Env) -> i128 {
+    bump_instance(e);
     e.storage()
         .instance()
         .get(&DataKey::TotalSupply)
@@ -54,6 +63,7 @@ pub fn read_total_supply(e: &Env) -> i128 {
 pub fn increase_supply(e: &Env, amount: i128) {
     let supply = read_total_supply(e);
     let new_supply = supply.checked_add(amount).expect("supply overflow");
+    bump_instance(e);
     e.storage()
         .instance()
         .set(&DataKey::TotalSupply, &new_supply);
@@ -65,6 +75,7 @@ pub fn decrease_supply(e: &Env, amount: i128) {
         panic!("supply cannot be negative");
     }
     let new_supply = supply.checked_sub(amount).expect("supply underflow");
+    bump_instance(e);
     e.storage()
         .instance()
         .set(&DataKey::TotalSupply, &new_supply);

--- a/veritixpay/contract/token/src/contract.rs
+++ b/veritixpay/contract/token/src/contract.rs
@@ -206,6 +206,7 @@ impl VeritixToken {
 
     /// Returns the current number of escrows created (monotonically increasing counter).
     pub fn escrow_count(e: Env) -> u32 {
+        crate::storage_types::bump_instance(&e);
         crate::storage_types::read_counter(&e, &crate::storage_types::DataKey::EscrowCount)
     }
 

--- a/veritixpay/contract/token/src/dispute.rs
+++ b/veritixpay/contract/token/src/dispute.rs
@@ -1,6 +1,6 @@
 use crate::balance::{receive_balance, spend_balance};
 use crate::escrow::get_escrow;
-use crate::storage_types::{increment_counter, write_persistent_record, DataKey};
+use crate::storage_types::{increment_counter, write_persistent_record, DataKey, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 #[contracttype]
@@ -65,12 +65,16 @@ pub fn open_dispute(e: &Env, claimant: Address, escrow_id: u32, resolver: Addres
         status: DisputeStatus::Open,
     };
 
+    let dispute_key = DataKey::Dispute(count);
+    let escrow_dispute_key = DataKey::EscrowDispute(escrow_id);
+    e.storage().persistent().set(&dispute_key, &record);
     e.storage()
         .persistent()
-        .set(&DataKey::Dispute(count), &record);
+        .extend_ttl(&dispute_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    e.storage().persistent().set(&escrow_dispute_key, &count);
     e.storage()
         .persistent()
-        .set(&DataKey::EscrowDispute(escrow_id), &count);
+        .extend_ttl(&escrow_dispute_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
     e.events().publish(
         (symbol_short!("dispute_opened"), escrow_id, claimant.clone()),
@@ -123,11 +127,15 @@ fn settle_escrow_by_outcome(e: &Env, escrow_id: u32, release_to_beneficiary: boo
 pub fn resolve_dispute(e: &Env, resolver: Address, dispute_id: u32, release_to_beneficiary: bool) {
     resolver.require_auth();
 
+    let dispute_key = DataKey::Dispute(dispute_id);
     let mut dispute: DisputeRecord = e
         .storage()
         .persistent()
-        .get(&DataKey::Dispute(dispute_id))
+        .get(&dispute_key)
         .expect("Dispute not found");
+    e.storage()
+        .persistent()
+        .extend_ttl(&dispute_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
     if dispute.status != DisputeStatus::Open {
         panic!("AlreadyResolved: This dispute has already been resolved");
@@ -145,9 +153,10 @@ pub fn resolve_dispute(e: &Env, resolver: Address, dispute_id: u32, release_to_b
         DisputeStatus::ResolvedForDepositor
     };
 
+    e.storage().persistent().set(&dispute_key, &dispute);
     e.storage()
         .persistent()
-        .set(&DataKey::Dispute(dispute_id), &dispute);
+        .extend_ttl(&dispute_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     e.storage()
         .persistent()
         .remove(&DataKey::EscrowDispute(dispute.escrow_id));
@@ -160,8 +169,14 @@ pub fn resolve_dispute(e: &Env, resolver: Address, dispute_id: u32, release_to_b
 
 /// Helper to read a dispute record.
 pub fn get_dispute(e: &Env, dispute_id: u32) -> DisputeRecord {
+    let key = DataKey::Dispute(dispute_id);
+    let record = e
+        .storage()
+        .persistent()
+        .get(&key)
+        .expect("Dispute not found");
     e.storage()
         .persistent()
-        .get(&DataKey::Dispute(dispute_id))
-        .expect("Dispute not found")
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    record
 }

--- a/veritixpay/contract/token/src/escrow_test.rs
+++ b/veritixpay/contract/token/src/escrow_test.rs
@@ -267,12 +267,6 @@ fn test_escrow_count_getter_reflects_creations() {
     let depositor_one = Address::generate(&e);
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor_one.clone(), amount);
-        let _ = VeritixToken::create_escrow(
-            e.clone(),
-            depositor_one.clone(),
-            beneficiary.clone(),
-            amount,
-        );
         let _ = VeritixToken::create_escrow(e.clone(), depositor_one.clone(), beneficiary.clone(), amount, 1000);
         assert_eq!(VeritixToken::escrow_count(e.clone()), 1);
     });
@@ -281,12 +275,6 @@ fn test_escrow_count_getter_reflects_creations() {
     let depositor_two = Address::generate(&e);
     e.as_contract(&contract_id, || {
         crate::balance::receive_balance(&e, depositor_two.clone(), amount);
-        let _ = VeritixToken::create_escrow(
-            e.clone(),
-            depositor_two.clone(),
-            beneficiary.clone(),
-            amount,
-        );
         let _ = VeritixToken::create_escrow(e.clone(), depositor_two.clone(), beneficiary.clone(), amount, 1000);
         assert_eq!(VeritixToken::escrow_count(e.clone()), 2);
     });
@@ -574,4 +562,71 @@ fn test_refund_escrow_emits_event() {
     assert_eq!(events.len(), 1);
     // Topics: (escrow_refunded, escrow_id, depositor), data: amount
     assert_eq!(events.first().unwrap().0.len(), 3);
+}
+
+#[test]
+#[should_panic(expected = "expiration ledger is in the past")]
+fn test_create_escrow_past_expiry_panics() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let amount = 1_000i128;
+
+    e.as_contract(&contract_id, || {
+        // Advance ledger so expiry_ledger = 0 is in the past
+        e.ledger().set_sequence_number(10);
+        crate::balance::receive_balance(&e, depositor.clone(), amount);
+        create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 0);
+    });
+}
+
+#[test]
+fn test_expired_escrow_can_be_refunded_by_third_party() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let third_party = Address::generate(&e);
+    let amount = 1_000i128;
+
+    let mut escrow_id = 0u32;
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, depositor.clone(), amount);
+        // Create escrow expiring at ledger 5
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 5);
+    });
+
+    e.as_contract(&contract_id, || {
+        // Advance past expiry
+        e.ledger().set_sequence_number(6);
+        let before = read_balance(&e, depositor.clone());
+        // Third party triggers refund after expiry
+        refund_escrow(&e, third_party.clone(), escrow_id);
+        let record = get_escrow(&e, escrow_id);
+        assert!(record.refunded);
+        assert_eq!(read_balance(&e, depositor.clone()), before + amount);
+    });
+}
+
+#[test]
+#[should_panic(expected = "not depositor")]
+fn test_non_expired_escrow_cannot_be_refunded_by_third_party() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let third_party = Address::generate(&e);
+    let amount = 1_000i128;
+
+    let mut escrow_id = 0u32;
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, depositor.clone(), amount);
+        escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
+    });
+
+    e.as_contract(&contract_id, || {
+        // Ledger has not advanced past expiry
+        refund_escrow(&e, third_party.clone(), escrow_id);
+    });
 }

--- a/veritixpay/contract/token/src/freeze.rs
+++ b/veritixpay/contract/token/src/freeze.rs
@@ -1,18 +1,22 @@
-use crate::storage_types::DataKey;
+use crate::storage_types::{DataKey, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
 use soroban_sdk::{symbol_short, Address, Env};
 
 pub fn is_frozen(e: &Env, addr: &Address) -> bool {
-    e.storage()
-        .persistent()
-        .get(&DataKey::Freeze(addr.clone()))
-        .unwrap_or(false)
+    let key = DataKey::Freeze(addr.clone());
+    let storage = e.storage().persistent();
+    let frozen = storage.get(&key).unwrap_or(false);
+    if frozen {
+        storage.extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    }
+    frozen
 }
 
 pub fn freeze_account(e: &Env, _admin: Address, target: Address) {
     let admin = _admin;
-    e.storage()
-        .persistent()
-        .set(&DataKey::Freeze(target.clone()), &true);
+    let key = DataKey::Freeze(target.clone());
+    let storage = e.storage().persistent();
+    storage.set(&key, &true);
+    storage.extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     e.events().publish((symbol_short!("frozen"), target), admin);
 }
 

--- a/veritixpay/contract/token/src/metadata.rs
+++ b/veritixpay/contract/token/src/metadata.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contracttype, Env, String};
 
-use crate::storage_types::DataKey;
+use crate::storage_types::{bump_instance, DataKey};
 use crate::validation::{require_decimal_within_max, require_nonempty_string};
 
 pub const MAX_DECIMALS: u32 = 18;
@@ -14,10 +14,12 @@ pub struct TokenMetadata {
 }
 
 pub fn read_metadata(e: &Env) -> TokenMetadata {
+    bump_instance(e);
     e.storage().instance().get(&DataKey::Metadata).unwrap()
 }
 
 pub fn write_metadata(e: &Env, metadata: TokenMetadata) {
+    bump_instance(e);
     e.storage().instance().set(&DataKey::Metadata, &metadata);
 }
 

--- a/veritixpay/contract/token/src/recurring.rs
+++ b/veritixpay/contract/token/src/recurring.rs
@@ -1,5 +1,5 @@
 use crate::balance::{receive_balance, spend_balance};
-use crate::storage_types::{increment_counter, DataKey};
+use crate::storage_types::{increment_counter, DataKey, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
 use crate::validation::require_positive_amount;
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
@@ -47,9 +47,11 @@ pub fn setup_recurring(
         last_charged_ledger: e.ledger().sequence(), // Set initial timestamp to now
         active: true,
     };
+    let key = DataKey::Recurring(count);
+    e.storage().persistent().set(&key, &record);
     e.storage()
         .persistent()
-        .set(&DataKey::Recurring(count), &record);
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
     // 4. Emit Observability Event
     e.events().publish(
@@ -63,11 +65,15 @@ pub fn setup_recurring(
 /// Executes a recurring payment if the interval has passed.
 /// Anyone can call this ("crank the contract"), but funds only move from payer to payee.
 pub fn execute_recurring(e: &Env, recurring_id: u32) {
+    let key = DataKey::Recurring(recurring_id);
     let mut record: RecurringRecord = e
         .storage()
         .persistent()
-        .get(&DataKey::Recurring(recurring_id))
+        .get(&key)
         .unwrap_or_else(|| panic!("recurring record not found"));
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
     if !record.active {
         panic!("recurring payment is not active");
@@ -90,9 +96,10 @@ pub fn execute_recurring(e: &Env, recurring_id: u32) {
     receive_balance(e, record.payee.clone(), record.amount);
 
     record.last_charged_ledger = current_ledger;
+    e.storage().persistent().set(&key, &record);
     e.storage()
         .persistent()
-        .set(&DataKey::Recurring(recurring_id), &record);
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
     e.events().publish(
         (symbol_short!("recurring_executed"), recurring_id),
@@ -104,10 +111,11 @@ pub fn execute_recurring(e: &Env, recurring_id: u32) {
 pub fn cancel_recurring(e: &Env, caller: Address, recurring_id: u32) {
     caller.require_auth();
 
+    let key = DataKey::Recurring(recurring_id);
     let mut record: RecurringRecord = e
         .storage()
         .persistent()
-        .get(&DataKey::Recurring(recurring_id))
+        .get(&key)
         .unwrap_or_else(|| panic!("recurring record not found"));
 
     if record.payer != caller {
@@ -115,9 +123,10 @@ pub fn cancel_recurring(e: &Env, caller: Address, recurring_id: u32) {
     }
 
     record.active = false;
+    e.storage().persistent().set(&key, &record);
     e.storage()
         .persistent()
-        .set(&DataKey::Recurring(recurring_id), &record);
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
     e.events().publish(
         (
@@ -130,8 +139,14 @@ pub fn cancel_recurring(e: &Env, caller: Address, recurring_id: u32) {
 }
 
 pub fn get_recurring(e: &Env, recurring_id: u32) -> RecurringRecord {
+    let key = DataKey::Recurring(recurring_id);
+    let record = e
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| panic!("recurring record not found"));
     e.storage()
         .persistent()
-        .get(&DataKey::Recurring(recurring_id))
-        .unwrap_or_else(|| panic!("recurring record not found"))
+        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    record
 }

--- a/veritixpay/contract/token/src/splitter.rs
+++ b/veritixpay/contract/token/src/splitter.rs
@@ -1,6 +1,7 @@
 use crate::balance::{receive_balance, spend_balance};
 use crate::storage_types::{
     increment_counter, read_persistent_record, write_persistent_record, DataKey,
+    PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD,
 };
 use crate::validation::require_positive_amount;
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
@@ -92,6 +93,11 @@ pub fn distribute(e: &Env, caller: Address, split_id: u32) {
         .persistent()
         .get(&DataKey::Split(split_id))
         .expect("split record not found");
+    e.storage().persistent().extend_ttl(
+        &DataKey::Split(split_id),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
 
     // 1. Rules: Caller must be sender, cannot distribute twice
     if record.sender != caller {
@@ -116,14 +122,20 @@ pub fn distribute(e: &Env, caller: Address, split_id: u32) {
             // Last recipient gets everything left to avoid rounding dust
             remaining_amount
         } else {
-            (record.total_amount * recipient.share_bps as i128) / 10000
+            record
+                .total_amount
+                .checked_mul(recipient.share_bps as i128)
+                .expect("split amount overflow")
+                / 10000
         };
 
         // Transfer from contract to recipient
         spend_balance(e, e.current_contract_address(), amount_to_send);
         receive_balance(e, recipient.address.clone(), amount_to_send);
 
-        remaining_amount -= amount_to_send;
+        remaining_amount = remaining_amount
+            .checked_sub(amount_to_send)
+            .expect("split remaining underflow");
     }
 
     // 3. Mark distributed
@@ -149,6 +161,11 @@ pub fn cancel_split(e: &Env, caller: Address, split_id: u32) {
         .persistent()
         .get(&DataKey::Split(split_id))
         .expect("split record not found");
+    e.storage().persistent().extend_ttl(
+        &DataKey::Split(split_id),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
 
     if record.sender != caller {
         panic!("unauthorized");

--- a/veritixpay/contract/token/src/storage_types.rs
+++ b/veritixpay/contract/token/src/storage_types.rs
@@ -6,6 +6,9 @@ pub const ALLOWANCE_LIFETIME_THRESHOLD: u32 = 518400; // ~30 days
 pub const ALLOWANCE_BUMP_AMOUNT: u32 = 535000;
 pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 518400;
 pub const INSTANCE_BUMP_AMOUNT: u32 = 535000;
+/// Threshold and bump for long-lived persistent records (escrow, split, dispute, recurring, freeze).
+pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 518400; // ~30 days
+pub const PERSISTENT_BUMP_AMOUNT: u32 = 535000;
 
 #[derive(Clone)]
 #[contracttype]
@@ -48,17 +51,29 @@ pub fn read_persistent_record<T>(e: &Env, key: &DataKey, missing_message: &'stat
 where
     T: TryFromVal<Env, Val>,
 {
-    e.storage()
-        .persistent()
+    let storage = e.storage().persistent();
+    let value = storage
         .get::<DataKey, T>(key)
-        .unwrap_or_else(|| panic!("{}", missing_message))
+        .unwrap_or_else(|| panic!("{}", missing_message));
+    storage.extend_ttl(key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    value
 }
 
 pub fn write_persistent_record<T>(e: &Env, key: &DataKey, value: &T)
 where
     T: IntoVal<Env, Val>,
 {
-    e.storage().persistent().set(key, value);
+    let storage = e.storage().persistent();
+    storage.set(key, value);
+    storage.extend_ttl(key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+}
+
+/// Bumps the instance storage TTL. Call this on any entrypoint that reads or
+/// writes instance-stored data (admin, metadata, counters, total supply).
+pub fn bump_instance(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 }
 
 pub fn read_counter(e: &Env, key: &DataKey) -> u32 {


### PR DESCRIPTION
## Summary

Resolves four issues assigned to PortableDD in a single PR.

Closes #83
Closes #84
Closes #85
Closes #86

---

## Issue #83 — Checked arithmetic helpers

- `balance.rs`: `receive_balance` and `spend_balance` now use `checked_add`/`checked_sub` instead of raw `+`/`-`, making overflow/underflow failures explicit and deterministic.
- `splitter.rs`: `distribute()` uses `checked_mul` for share calculation and `checked_sub` for the running remainder, eliminating silent overflow on large amounts.

## Issue #84 — Consistent TTL management

- `storage_types.rs`: Added `PERSISTENT_LIFETIME_THRESHOLD`/`PERSISTENT_BUMP_AMOUNT` constants for long-lived records. `read_persistent_record` and `write_persistent_record` now call `extend_ttl` on every access. Added `bump_instance()` helper.
- `admin.rs`, `metadata.rs`: Call `bump_instance()` on every read/write of instance storage.
- `balance.rs`: Supply functions (`read_total_supply`, `increase_supply`, `decrease_supply`) call `bump_instance()`.
- `freeze.rs`, `recurring.rs`, `dispute.rs`, `splitter.rs`: All persistent reads and writes now call `extend_ttl` with the shared constants.

**TTL policy:** Instance storage (admin, metadata, counters, total supply) is bumped on every entrypoint that touches it. Persistent records (escrow, split, dispute, recurring, freeze) are bumped on every read and write. `Freeze(false)` entries are removed rather than stored (existing behaviour via `unfreeze_account`).

## Issue #85 — Escrow entrypoints on VeritixToken

`contract.rs` already exposes `create_escrow`, `release_escrow`, `refund_escrow`, `get_escrow`, and `escrow_count` through the public `VeritixToken` interface. Fixed broken test calls in `escrow_test.rs` that were passing the wrong number of arguments to `VeritixToken::create_escrow` (missing `expiry_ledger`).

## Issue #86 — Escrow input validation and lifecycle

`escrow.rs` already validates positive amount, rejects same depositor/beneficiary, and enforces `expiry_ledger >= current_ledger`. Added three new tests to `escrow_test.rs`:

- `test_create_escrow_past_expiry_panics` — creating an escrow with a past expiry ledger panics.
- `test_expired_escrow_can_be_refunded_by_third_party` — after expiry, anyone can trigger a refund back to the depositor.
- `test_non_expired_escrow_cannot_be_refunded_by_third_party` — before expiry, only the depositor can refund.

**Policy note:** `depositor == beneficiary` is rejected (`InvalidEscrow` panic). This is documented in the code.

---

## Files changed

| File | Change |
|------|--------|
| `src/balance.rs` | Checked arithmetic in `receive_balance`/`spend_balance`; `bump_instance` in supply functions |
| `src/storage_types.rs` | `PERSISTENT_*` constants; TTL bumps in `read/write_persistent_record`; `bump_instance()` helper |
| `src/admin.rs` | `bump_instance` on read/write |
| `src/metadata.rs` | `bump_instance` on read/write |
| `src/freeze.rs` | `extend_ttl` on freeze read/write |
| `src/recurring.rs` | `extend_ttl` on all persistent reads/writes |
| `src/dispute.rs` | `extend_ttl` on all persistent reads/writes |
| `src/splitter.rs` | Checked arithmetic; `extend_ttl` on raw persistent reads |
| `src/contract.rs` | `bump_instance` in `escrow_count` |
| `src/escrow_test.rs` | Fix broken arg count; add 3 expiry/lifecycle tests |

## Testing

Rust is not installed in this environment so tests could not be run locally. All changes are consistent with the existing test patterns and the Soroban SDK API.