### PR TITLE
feat: validation tests, i128 boundary tests, integration test, depositor escrow index

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,57 @@ make clean    # remove build artifacts
 
 ---
 
+### Localnet Integration Test
+
+The integration test deploys the compiled WASM to a local Soroban node and runs the full ticket purchase flow end-to-end: initialize → mint → create_escrow → release_escrow → assert balance.
+
+**Prerequisites**
+
+| Tool | Notes | Install |
+|------|-------|---------|
+| Docker | Required to run the Stellar quickstart image | https://docs.docker.com/get-docker |
+| stellar CLI | Already required for building | `cargo install stellar-cli` |
+
+**Start a local Soroban node**
+
+```bash
+docker run --rm -it \
+  -p 8000:8000 \
+  --name stellar \
+  stellar/quickstart:latest \
+  --standalone \
+  --enable-soroban-rpc
+```
+
+Wait until you see `Soroban RPC running` in the logs (usually ~10 seconds).
+
+**Run the integration test**
+
+```bash
+cd veritixpay/contract/token
+make integration-test
+```
+
+The script will build the contract, deploy it to localnet, run the full flow, and print `✅ Integration test passed` on success.
+
+**Environment overrides**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STELLAR_NETWORK` | `standalone` | Network name passed to stellar CLI |
+| `STELLAR_RPC_URL` | `http://localhost:8000/soroban/rpc` | Soroban RPC endpoint |
+| `STELLAR_NETWORK_PASSPHRASE` | `Standalone Network ; February 2017` | Network passphrase |
+
+```bash
+# Example: run against testnet
+STELLAR_NETWORK=testnet \
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org \
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015" \
+make integration-test
+```
+
+---
+
 ## Project Structure
 
 ```

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Integration test: deploys the contract to localnet and runs the full ticket purchase flow.
+# Prerequisites: stellar CLI, a running localnet (see README.md for setup).
+set -euo pipefail
+
+NETWORK="${STELLAR_NETWORK:-standalone}"
+RPC_URL="${STELLAR_RPC_URL:-http://localhost:8000/soroban/rpc}"
+PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
+
+WASM_PATH="../../target/wasm32v1-none/release/veritixpay_token.wasm"
+
+echo "==> Building contract..."
+make build
+
+echo "==> Generating test identities..."
+stellar keys generate admin    --network "$NETWORK" --rpc-url "$RPC_URL" --network-passphrase "$PASSPHRASE" 2>/dev/null || true
+stellar keys generate buyer    --network "$NETWORK" --rpc-url "$RPC_URL" --network-passphrase "$PASSPHRASE" 2>/dev/null || true
+stellar keys generate seller   --network "$NETWORK" --rpc-url "$RPC_URL" --network-passphrase "$PASSPHRASE" 2>/dev/null || true
+
+ADMIN_ADDR=$(stellar keys address admin)
+BUYER_ADDR=$(stellar keys address buyer)
+SELLER_ADDR=$(stellar keys address seller)
+
+echo "  admin:  $ADMIN_ADDR"
+echo "  buyer:  $BUYER_ADDR"
+echo "  seller: $SELLER_ADDR"
+
+echo "==> Funding accounts via friendbot..."
+curl -s "http://localhost:8000/friendbot?addr=$ADMIN_ADDR"  > /dev/null
+curl -s "http://localhost:8000/friendbot?addr=$BUYER_ADDR"  > /dev/null
+curl -s "http://localhost:8000/friendbot?addr=$SELLER_ADDR" > /dev/null
+
+echo "==> Deploying contract..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_PATH" \
+  --source admin \
+  --network "$NETWORK" \
+  --rpc-url "$RPC_URL" \
+  --network-passphrase "$PASSPHRASE")
+echo "  contract: $CONTRACT_ID"
+
+invoke() {
+  stellar contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$1" \
+    --network "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    --network-passphrase "$PASSPHRASE" \
+    -- "${@:2}"
+}
+
+echo "==> Initializing contract..."
+invoke admin initialize \
+  --admin "$ADMIN_ADDR" \
+  --name  "Veritix" \
+  --symbol "VTX" \
+  --decimal 7
+
+echo "==> Minting 1000 VTX to buyer..."
+invoke admin mint \
+  --admin "$ADMIN_ADDR" \
+  --to    "$BUYER_ADDR" \
+  --amount 1000
+
+echo "==> Creating escrow (buyer -> seller, 1000 VTX)..."
+ESCROW_ID=$(invoke buyer create_escrow \
+  --depositor    "$BUYER_ADDR" \
+  --beneficiary  "$SELLER_ADDR" \
+  --amount       1000 \
+  --expiry_ledger 999999)
+echo "  escrow_id: $ESCROW_ID"
+
+echo "==> Releasing escrow..."
+invoke seller release_escrow \
+  --caller    "$SELLER_ADDR" \
+  --escrow_id "$ESCROW_ID"
+
+echo "==> Asserting seller balance == 1000..."
+SELLER_BALANCE=$(invoke admin balance --id "$SELLER_ADDR")
+if [ "$SELLER_BALANCE" != "1000" ]; then
+  echo "FAIL: expected seller balance 1000, got $SELLER_BALANCE"
+  exit 1
+fi
+
+echo "✅ Integration test passed. Seller balance: $SELLER_BALANCE"

--- a/veritixpay/contract/token/Makefile
+++ b/veritixpay/contract/token/Makefile
@@ -42,3 +42,7 @@ deploy:
 # Invoke a contract function. Usage: make invoke ARGS="balance alice"
 invoke:
 	bash $(CURDIR)/../../../scripts/invoke.sh $(ARGS)
+
+# Run the full localnet integration test (requires a running localnet — see README.md)
+integration-test:
+	bash $(CURDIR)/../../../scripts/integration_test.sh

--- a/veritixpay/contract/token/src/contract.rs
+++ b/veritixpay/contract/token/src/contract.rs
@@ -6,7 +6,8 @@ use crate::balance::{
 };
 use crate::dispute::{get_dispute as dispute_get, open_dispute, resolve_dispute, DisputeRecord};
 use crate::escrow::{
-    create_escrow as escrow_create, get_escrow as escrow_get, refund_escrow as escrow_refund,
+    create_escrow as escrow_create, get_escrow as escrow_get,
+    get_escrows_by_depositor as escrow_get_by_depositor, refund_escrow as escrow_refund,
     release_escrow as escrow_release, EscrowRecord,
 };
 use crate::freeze::{freeze_account, is_frozen as read_frozen_status, unfreeze_account};
@@ -207,6 +208,11 @@ impl VeritixToken {
     /// Returns the current number of escrows created (monotonically increasing counter).
     pub fn escrow_count(e: Env) -> u32 {
         crate::storage_types::read_counter(&e, &crate::storage_types::DataKey::EscrowCount)
+    }
+
+    /// Returns all escrow IDs created by a given depositor.
+    pub fn escrows_by_depositor(e: Env, depositor: Address) -> Vec<u32> {
+        escrow_get_by_depositor(&e, depositor)
     }
 
     // --- Dispute ---

--- a/veritixpay/contract/token/src/escrow.rs
+++ b/veritixpay/contract/token/src/escrow.rs
@@ -3,7 +3,7 @@ use crate::storage_types::{
     increment_counter, read_persistent_record, write_persistent_record, DataKey,
 };
 use crate::validation::{require_current_or_future_ledger, require_positive_amount};
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -54,6 +54,16 @@ pub fn create_escrow(
         expiry_ledger,
     };
     write_persistent_record(e, &DataKey::Escrow(count), &record);
+
+    // Append escrow ID to the depositor's list
+    let key = DataKey::DepositorEscrows(depositor.clone());
+    let mut ids: Vec<u32> = e
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(e));
+    ids.push_back(count);
+    e.storage().persistent().set(&key, &ids);
 
     // Optional observability event
     e.events().publish(
@@ -168,4 +178,12 @@ pub fn try_get_escrow(e: &Env, escrow_id: u32) -> Result<EscrowRecord, &'static 
     } else {
         Err("escrow not found")
     }
+}
+
+// Returns all escrow IDs created by a given depositor.
+pub fn get_escrows_by_depositor(e: &Env, depositor: Address) -> Vec<u32> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::DepositorEscrows(depositor))
+        .unwrap_or_else(|| Vec::new(e))
 }

--- a/veritixpay/contract/token/src/escrow_test.rs
+++ b/veritixpay/contract/token/src/escrow_test.rs
@@ -575,3 +575,121 @@ fn test_refund_escrow_emits_event() {
     // Topics: (escrow_refunded, escrow_id, depositor), data: amount
     assert_eq!(events.first().unwrap().0.len(), 3);
 }
+
+// --- Issue #171: i128 boundary tests ---
+
+#[test]
+fn test_escrow_amount_of_one() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, depositor.clone(), 1);
+        let escrow_id = create_escrow(&e, depositor.clone(), beneficiary.clone(), 1, 1000);
+        let record = get_escrow(&e, escrow_id);
+        assert_eq!(record.amount, 1);
+    });
+}
+
+// --- Issue #173: DepositorEscrows tests ---
+
+#[test]
+fn test_get_escrows_by_depositor_empty_before_any_escrow() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+
+    e.as_contract(&contract_id, || {
+        let ids = crate::escrow::get_escrows_by_depositor(&e, depositor.clone());
+        assert_eq!(ids.len(), 0);
+    });
+}
+
+#[test]
+fn test_get_escrows_by_depositor_grows_with_each_escrow() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let amount = 100i128;
+
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, depositor.clone(), amount * 3);
+
+        let id1 = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
+        let ids = crate::escrow::get_escrows_by_depositor(&e, depositor.clone());
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids.get(0).unwrap(), id1);
+
+        let id2 = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
+        let ids = crate::escrow::get_escrows_by_depositor(&e, depositor.clone());
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids.get(1).unwrap(), id2);
+
+        let id3 = create_escrow(&e, depositor.clone(), beneficiary.clone(), amount, 1000);
+        let ids = crate::escrow::get_escrows_by_depositor(&e, depositor.clone());
+        assert_eq!(ids.len(), 3);
+        assert_eq!(ids.get(2).unwrap(), id3);
+    });
+}
+
+#[test]
+fn test_get_escrows_by_depositor_returns_correct_ids() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor_a = Address::generate(&e);
+    let depositor_b = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let amount = 50i128;
+
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, depositor_a.clone(), amount * 2);
+        crate::balance::receive_balance(&e, depositor_b.clone(), amount);
+
+        let id_a1 = create_escrow(&e, depositor_a.clone(), beneficiary.clone(), amount, 1000);
+        let _id_b = create_escrow(&e, depositor_b.clone(), beneficiary.clone(), amount, 1000);
+        let id_a2 = create_escrow(&e, depositor_a.clone(), beneficiary.clone(), amount, 1000);
+
+        let ids_a = crate::escrow::get_escrows_by_depositor(&e, depositor_a.clone());
+        assert_eq!(ids_a.len(), 2);
+        assert_eq!(ids_a.get(0).unwrap(), id_a1);
+        assert_eq!(ids_a.get(1).unwrap(), id_a2);
+
+        let ids_b = crate::escrow::get_escrows_by_depositor(&e, depositor_b.clone());
+        assert_eq!(ids_b.len(), 1);
+    });
+}
+
+#[test]
+fn test_escrows_by_depositor_via_contract_interface() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let depositor = Address::generate(&e);
+    let beneficiary = Address::generate(&e);
+    let amount = 200i128;
+
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, depositor.clone(), amount * 2);
+        let id1 = VeritixToken::create_escrow(
+            e.clone(),
+            depositor.clone(),
+            beneficiary.clone(),
+            amount,
+            1000,
+        );
+        let id2 = VeritixToken::create_escrow(
+            e.clone(),
+            depositor.clone(),
+            beneficiary.clone(),
+            amount,
+            1000,
+        );
+
+        let ids = VeritixToken::escrows_by_depositor(e.clone(), depositor.clone());
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids.get(0).unwrap(), id1);
+        assert_eq!(ids.get(1).unwrap(), id2);
+    });
+}

--- a/veritixpay/contract/token/src/lib.rs
+++ b/veritixpay/contract/token/src/lib.rs
@@ -39,4 +39,7 @@ mod dispute_test;
 #[cfg(test)]
 mod recurring_test;
 
+#[cfg(test)]
+mod validation_test;
+
 pub use crate::contract::VeritixToken;

--- a/veritixpay/contract/token/src/recurring_test.rs
+++ b/veritixpay/contract/token/src/recurring_test.rs
@@ -293,3 +293,49 @@ mod recurring_tests {
         assert_eq!(events.first().unwrap().0.len(), 3);
     }
 }
+
+// --- Issue #171: i128 boundary tests ---
+
+#[cfg(test)]
+mod recurring_boundary_tests {
+    use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
+
+    use crate::contract::VeritixToken;
+    use crate::recurring::{execute_recurring, setup_recurring};
+
+    fn setup_env() -> Env {
+        let e = Env::default();
+        e.mock_all_auths();
+        e
+    }
+
+    #[test]
+    fn test_recurring_minimum_interval() {
+        let e = setup_env();
+        let contract_id = e.register_contract(None, VeritixToken);
+        let payer = Address::generate(&e);
+        let payee = Address::generate(&e);
+        let amount = 100i128;
+
+        let mut id = 0u32;
+        e.as_contract(&contract_id, || {
+            crate::balance::receive_balance(&e, payer.clone(), amount * 3);
+            // interval = 1: executes on every ledger advance
+            id = setup_recurring(&e, payer.clone(), payee.clone(), amount, 1);
+        });
+
+        // Advance ledger by 1 and execute
+        e.ledger().with_mut(|l| l.sequence_number += 1);
+        e.as_contract(&contract_id, || {
+            execute_recurring(&e, id);
+            assert_eq!(crate::balance::read_balance(&e, payee.clone()), amount);
+        });
+
+        // Advance again and execute a second time
+        e.ledger().with_mut(|l| l.sequence_number += 1);
+        e.as_contract(&contract_id, || {
+            execute_recurring(&e, id);
+            assert_eq!(crate::balance::read_balance(&e, payee.clone()), amount * 2);
+        });
+    }
+}

--- a/veritixpay/contract/token/src/splitter_test.rs
+++ b/veritixpay/contract/token/src/splitter_test.rs
@@ -391,3 +391,25 @@ fn test_cancel_split_emits_event() {
     // Topics: (split_cancelled, split_id, caller), data: total_amount
     assert_eq!(events.first().unwrap().0.len(), 3);
 }
+
+// --- Issue #171: i128 boundary tests ---
+
+#[test]
+fn test_split_with_single_recipient_full_bps() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let sender = Address::generate(&e);
+    let recipient = Address::generate(&e);
+    let amount = 1_000_000i128;
+
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, sender.clone(), amount);
+        let recipients = make_recipients(&e, &[(recipient.clone(), 10000)]);
+        let split_id = create_split(&e, sender.clone(), recipients, amount);
+        distribute(&e, sender.clone(), split_id);
+
+        // Single recipient with 10000 bps gets all funds
+        assert_eq!(crate::balance::read_balance(&e, recipient.clone()), amount);
+        assert_eq!(crate::balance::read_balance(&e, sender.clone()), 0);
+    });
+}

--- a/veritixpay/contract/token/src/storage_types.rs
+++ b/veritixpay/contract/token/src/storage_types.rs
@@ -42,6 +42,9 @@ pub enum DataKey {
 
     // Stores per-address freeze status.
     Freeze(Address),
+
+    // Stores the list of escrow IDs created by a given depositor.
+    DepositorEscrows(Address),
 }
 
 pub fn read_persistent_record<T>(e: &Env, key: &DataKey, missing_message: &'static str) -> T

--- a/veritixpay/contract/token/src/test.rs
+++ b/veritixpay/contract/token/src/test.rs
@@ -544,3 +544,41 @@ fn test_set_admin_emits_event() {
     // Topics: (admin_set, current_admin), data: new_admin
     assert_eq!(events.first().unwrap().0.len(), 2);
 }
+
+// --- Issue #171: i128 boundary tests ---
+
+#[test]
+fn test_mint_i128_max_amount() {
+    let (env, admin, user) = setup();
+    env.mock_all_auths();
+    let client = create_client(&env);
+    initialize_client(&client, &env, &admin, 7);
+
+    client.mint(&admin, &user, &i128::MAX);
+    assert_eq!(client.balance(&user), i128::MAX);
+}
+
+#[test]
+#[should_panic(expected = "supply overflow")]
+fn test_mint_overflow_panics() {
+    let (env, admin, user) = setup();
+    env.mock_all_auths();
+    let client = create_client(&env);
+    initialize_client(&client, &env, &admin, 7);
+
+    client.mint(&admin, &user, &i128::MAX);
+    client.mint(&admin, &user, &1i128);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_transfer_zero_amount_panics() {
+    let (env, admin, user) = setup();
+    env.mock_all_auths();
+    let (_, user2) = (Address::generate(&env), Address::generate(&env));
+    let client = create_client(&env);
+    initialize_client(&client, &env, &admin, 7);
+
+    client.mint(&admin, &user, &1000i128);
+    client.transfer(&user, &user2, &0i128);
+}

--- a/veritixpay/contract/token/src/validation_test.rs
+++ b/veritixpay/contract/token/src/validation_test.rs
@@ -1,0 +1,104 @@
+#[cfg(test)]
+mod validation_tests {
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    use crate::validation::{
+        require_current_or_future_ledger, require_decimal_within_max, require_nonempty_string,
+        require_not_frozen_account, require_positive_amount,
+    };
+
+    fn setup() -> Env {
+        let e = Env::default();
+        e.mock_all_auths();
+        e
+    }
+
+    // --- require_positive_amount ---
+
+    #[test]
+    fn test_require_positive_amount_accepts_positive() {
+        require_positive_amount(1);
+        require_positive_amount(i128::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_require_positive_amount_rejects_zero() {
+        require_positive_amount(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_require_positive_amount_rejects_negative() {
+        require_positive_amount(-1);
+    }
+
+    // --- require_nonempty_string ---
+
+    #[test]
+    fn test_require_nonempty_string_accepts_nonempty() {
+        let e = setup();
+        let s = String::from_str(&e, "hello");
+        require_nonempty_string(&s, "must not be empty");
+    }
+
+    #[test]
+    #[should_panic(expected = "must not be empty")]
+    fn test_require_nonempty_string_rejects_empty() {
+        let e = setup();
+        let s = String::from_str(&e, "");
+        require_nonempty_string(&s, "must not be empty");
+    }
+
+    // --- require_decimal_within_max ---
+
+    #[test]
+    fn test_require_decimal_within_max_accepts_eighteen() {
+        require_decimal_within_max(18, 18);
+    }
+
+    #[test]
+    #[should_panic(expected = "decimal exceeds maximum")]
+    fn test_require_decimal_within_max_rejects_nineteen() {
+        require_decimal_within_max(19, 18);
+    }
+
+    // --- require_current_or_future_ledger ---
+
+    #[test]
+    fn test_require_current_or_future_ledger_accepts_current() {
+        // expiry == current ledger is valid
+        require_current_or_future_ledger(100, 100);
+    }
+
+    #[test]
+    #[should_panic(expected = "expiration ledger is in the past")]
+    fn test_require_current_or_future_ledger_rejects_past() {
+        require_current_or_future_ledger(100, 99);
+    }
+
+    // --- require_not_frozen_account ---
+
+    #[test]
+    fn test_require_not_frozen_account_accepts_unfrozen() {
+        let e = setup();
+        let contract_id = e.register_contract(None, crate::contract::VeritixToken);
+        let addr = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            // Account is not frozen by default — should not panic
+            require_not_frozen_account(&e, &addr);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "account frozen")]
+    fn test_require_not_frozen_account_rejects_frozen() {
+        let e = setup();
+        let contract_id = e.register_contract(None, crate::contract::VeritixToken);
+        let addr = Address::generate(&e);
+        e.as_contract(&contract_id, || {
+            crate::freeze::freeze_account(&e, addr.clone(), addr.clone());
+            require_not_frozen_account(&e, &addr);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Resolves four open issues assigned to @temiport25.

---

### Closes #170 — validation_test.rs

Created `src/validation_test.rs` with 11 unit tests covering every validation helper in `validation.rs`:
- `require_positive_amount`: accepts positive, rejects zero and negative
- `require_nonempty_string`: accepts non-empty, rejects empty
- `require_decimal_within_max`: accepts 18, rejects 19
- `require_current_or_future_ledger`: accepts current ledger, rejects past
- `require_not_frozen_account`: accepts unfrozen, rejects frozen

---

### Closes #171 — i128 boundary tests

Added boundary tests across all relevant modules:
- **test.rs**: `test_mint_i128_max_amount`, `test_mint_overflow_panics` (`#[should_panic(expected = "supply overflow")]`), `test_transfer_zero_amount_panics`
- **escrow_test.rs**: `test_escrow_amount_of_one` (minimum valid escrow)
- **splitter_test.rs**: `test_split_with_single_recipient_full_bps` (10000 bps → all funds)
- **recurring_test.rs**: `test_recurring_minimum_interval` (interval = 1, executes every ledger)

---

### Closes #172 — localnet integration test

- **scripts/integration_test.sh**: builds the contract, deploys to localnet, runs initialize → mint → create_escrow → release_escrow → asserts seller balance
- **Makefile**: added `integration-test` target
- **README.md**: documented localnet setup with Docker quickstart, environment variable overrides, and usage instructions

---

### Closes #173 — per-depositor escrow index

- **storage_types.rs**: added `DataKey::DepositorEscrows(Address)` storing `Vec<u32>`
- **escrow.rs**: `create_escrow` now appends the new ID to the depositor's list; added `get_escrows_by_depositor(e, depositor) -> Vec<u32>`
- **contract.rs**: exposed as `escrows_by_depositor(e, depositor) -> Vec<u32>`
- **escrow_test.rs**: 4 new tests — empty before any escrow, list grows with each creation, IDs are correct per depositor, accessible via contract interface

---

## Testing

All new code compiles cleanly. Pre-existing test failures in `admin_test.rs`, `event_test.rs`, `dispute_test.rs`, `recurring_test.rs`, and `test.rs` are unrelated to this PR (they exist on `main` before these changes).