### PR TITLE
split count public getter, events distribution feature

### DIFF
--- a/veritixpay/contract/token/src/contract.rs
+++ b/veritixpay/contract/token/src/contract.rs
@@ -236,6 +236,12 @@ impl VeritixToken {
         dispute_get(&e, dispute_id)
     }
 
+    /// Returns the current number of disputes created (monotonically increasing counter).
+    pub fn dispute_count(e: Env) -> u32 {
+        crate::storage_types::bump_instance(&e);
+        crate::storage_types::read_counter(&e, &crate::storage_types::DataKey::DisputeCount)
+    }
+
     // --- Splitter ---
 
     pub fn create_split(
@@ -257,6 +263,12 @@ impl VeritixToken {
 
     pub fn get_split(e: Env, split_id: u32) -> SplitRecord {
         split_get(&e, split_id)
+    }
+
+    /// Returns the current number of splits created (monotonically increasing counter).
+    pub fn split_count(e: Env) -> u32 {
+        crate::storage_types::bump_instance(&e);
+        crate::storage_types::read_counter(&e, &crate::storage_types::DataKey::SplitCount)
     }
 
     // --- Recurring Payments ---
@@ -281,5 +293,11 @@ impl VeritixToken {
 
     pub fn get_recurring(e: Env, recurring_id: u32) -> RecurringRecord {
         get_recurring(&e, recurring_id)
+    }
+
+    /// Returns the current number of recurring payments created (monotonically increasing counter).
+    pub fn recurring_count(e: Env) -> u32 {
+        crate::storage_types::bump_instance(&e);
+        crate::storage_types::read_counter(&e, &crate::storage_types::DataKey::RecurringCount)
     }
 }

--- a/veritixpay/contract/token/src/dispute_test.rs
+++ b/veritixpay/contract/token/src/dispute_test.rs
@@ -4,6 +4,7 @@ use crate::balance::read_balance;
 use crate::contract::VeritixToken;
 use crate::dispute::{get_dispute, open_dispute, resolve_dispute, DisputeStatus};
 use crate::escrow::{create_escrow, get_escrow};
+use crate::storage_types::{read_counter, DataKey};
 
 fn setup_env() -> Env {
     let e = Env::default();
@@ -282,4 +283,49 @@ fn test_resolve_dispute_emits_event() {
     // Last event should be dispute_resolved with 3 topics
     let last = events.last().unwrap();
     assert_eq!(last.0.len(), 3);
+}
+
+// --- Dispute counter tests ---
+
+#[test]
+fn test_dispute_count_starts_at_zero() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+
+    e.as_contract(&contract_id, || {
+        let count = read_counter(&e, &DataKey::DisputeCount);
+        assert_eq!(count, 0);
+    });
+}
+
+#[test]
+fn test_dispute_count_increments_on_open() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let resolver = Address::generate(&e);
+
+    // Create three escrows for three disputes
+    let (depositor1, _beneficiary1, escrow_id1) = setup_escrow(&e, &contract_id);
+    let (depositor2, _beneficiary2, escrow_id2) = setup_escrow(&e, &contract_id);
+    let (depositor3, _beneficiary3, escrow_id3) = setup_escrow(&e, &contract_id);
+
+    e.as_contract(&contract_id, || {
+        // Before any disputes
+        assert_eq!(read_counter(&e, &DataKey::DisputeCount), 0);
+
+        // Open first dispute
+        let dispute_id = open_dispute(&e, depositor1.clone(), escrow_id1, resolver.clone());
+        assert_eq!(dispute_id, 1);
+        assert_eq!(read_counter(&e, &DataKey::DisputeCount), 1);
+
+        // Open second dispute
+        let dispute_id = open_dispute(&e, depositor2.clone(), escrow_id2, resolver.clone());
+        assert_eq!(dispute_id, 2);
+        assert_eq!(read_counter(&e, &DataKey::DisputeCount), 2);
+
+        // Open third dispute
+        let dispute_id = open_dispute(&e, depositor3.clone(), escrow_id3, resolver.clone());
+        assert_eq!(dispute_id, 3);
+        assert_eq!(read_counter(&e, &DataKey::DisputeCount), 3);
+    });
 }

--- a/veritixpay/contract/token/src/recurring_test.rs
+++ b/veritixpay/contract/token/src/recurring_test.rs
@@ -8,6 +8,7 @@ mod recurring_tests {
     use crate::balance::read_balance;
     use crate::contract::{VeritixToken, VeritixTokenClient};
     use crate::recurring::{cancel_recurring, execute_recurring, get_recurring, setup_recurring};
+    use crate::storage_types::{read_counter, DataKey};
 
     fn setup_env() -> Env {
         let e = Env::default();
@@ -333,5 +334,54 @@ mod recurring_tests {
         assert_eq!(events.len(), 1);
         // Topics: (recurring_cancelled, recurring_id, caller), data: ()
         assert_eq!(events.first().unwrap().0.len(), 3);
+    }
+
+    // --- Recurring counter tests ---
+
+    #[test]
+    fn test_recurring_count_starts_at_zero() {
+        let e = setup_env();
+        let contract_id = e.register_contract(None, VeritixToken);
+
+        e.as_contract(&contract_id, || {
+            let count = read_counter(&e, &DataKey::RecurringCount);
+            assert_eq!(count, 0);
+        });
+    }
+
+    #[test]
+    fn test_recurring_count_increments_on_setup() {
+        let e = setup_env();
+        let contract_id = e.register_contract(None, VeritixToken);
+        let payer1 = Address::generate(&e);
+        let payee1 = Address::generate(&e);
+        let payer2 = Address::generate(&e);
+        let payee2 = Address::generate(&e);
+        let payer3 = Address::generate(&e);
+        let payee3 = Address::generate(&e);
+
+        e.as_contract(&contract_id, || {
+            crate::balance::receive_balance(&e, payer1.clone(), 1000);
+            crate::balance::receive_balance(&e, payer2.clone(), 1000);
+            crate::balance::receive_balance(&e, payer3.clone(), 1000);
+
+            // Before any recurring payments
+            assert_eq!(read_counter(&e, &DataKey::RecurringCount), 0);
+
+            // Setup first recurring
+            let id = setup_recurring(&e, payer1.clone(), payee1.clone(), 500, 100);
+            assert_eq!(id, 1);
+            assert_eq!(read_counter(&e, &DataKey::RecurringCount), 1);
+
+            // Setup second recurring
+            let id = setup_recurring(&e, payer2.clone(), payee2.clone(), 500, 100);
+            assert_eq!(id, 2);
+            assert_eq!(read_counter(&e, &DataKey::RecurringCount), 2);
+
+            // Setup third recurring
+            let id = setup_recurring(&e, payer3.clone(), payee3.clone(), 500, 100);
+            assert_eq!(id, 3);
+            assert_eq!(read_counter(&e, &DataKey::RecurringCount), 3);
+        });
     }
 }

--- a/veritixpay/contract/token/src/splitter_test.rs
+++ b/veritixpay/contract/token/src/splitter_test.rs
@@ -4,6 +4,7 @@ use crate::balance::read_balance;
 use crate::balance::read_total_supply;
 use crate::contract::VeritixToken;
 use crate::splitter::{cancel_split, create_split, distribute, get_split, SplitRecipient};
+use crate::storage_types::{read_counter, DataKey};
 
 fn setup_env() -> Env {
     let e = Env::default();
@@ -390,4 +391,50 @@ fn test_cancel_split_emits_event() {
     assert_eq!(events.len(), 1);
     // Topics: (split_cancelled, split_id, caller), data: total_amount
     assert_eq!(events.first().unwrap().0.len(), 3);
+}
+
+// --- Split counter tests ---
+
+#[test]
+fn test_split_count_starts_at_zero() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+
+    e.as_contract(&contract_id, || {
+        let count = read_counter(&e, &DataKey::SplitCount);
+        assert_eq!(count, 0);
+    });
+}
+
+#[test]
+fn test_split_count_increments_on_create() {
+    let e = setup_env();
+    let contract_id = e.register_contract(None, VeritixToken);
+    let sender = Address::generate(&e);
+    let r1 = Address::generate(&e);
+
+    e.as_contract(&contract_id, || {
+        crate::balance::receive_balance(&e, sender.clone(), 3000);
+
+        // Before any splits
+        assert_eq!(read_counter(&e, &DataKey::SplitCount), 0);
+
+        // Create first split
+        let recipients = make_recipients(&e, &[(r1.clone(), 10000)]);
+        let split_id = create_split(&e, sender.clone(), recipients, 1000);
+        assert_eq!(split_id, 1);
+        assert_eq!(read_counter(&e, &DataKey::SplitCount), 1);
+
+        // Create second split
+        let recipients = make_recipients(&e, &[(r1.clone(), 10000)]);
+        let split_id = create_split(&e, sender.clone(), recipients, 1000);
+        assert_eq!(split_id, 2);
+        assert_eq!(read_counter(&e, &DataKey::SplitCount), 2);
+
+        // Create third split
+        let recipients = make_recipients(&e, &[(r1.clone(), 10000)]);
+        let split_id = create_split(&e, sender.clone(), recipients, 1000);
+        assert_eq!(split_id, 3);
+        assert_eq!(read_counter(&e, &DataKey::SplitCount), 3);
+    });
 }


### PR DESCRIPTION
Summary of Implementation
1. Added Three Public Getter Functions to [contract.rs]
split_count(e: Env) -> u32 (line 269-272): Returns the total number of splits created
recurring_count(e: Env) -> u32 (line 299-302): Returns the total number of recurring payments created
dispute_count(e: Env) -> u32 (line 241-244): Returns the total number of disputes created
Each function follows the same pattern as the existing escrow_count function:
Calls bump_instance to extend TTL
Reads the corresponding counter from storage using read_counter
2. Added Comprehensive Tests for each counter:
In [splitter_test.rs]
test_split_count_starts_at_zero: Verifies counter starts at 0
test_split_count_increments_on_create: Verifies counter increments correctly (tests 3 splits with IDs 1, 2, 3)
In [recurring_test.rs
test_recurring_count_starts_at_zero: Verifies counter starts at 0
test_recurring_count_increments_on_setup: Verifies counter increments correctly (tests 3 recurring payments with IDs 1, 2, 3)
In [dispute_test.rs]
test_dispute_count_starts_at_zero: Verifies counter starts at 0
test_dispute_count_increments_on_open: Verifies counter increments correctly (tests 3 disputes with IDs 1, 2, 3)
3. Purpose:
These public getters expose the counter keys that already existed in DataKey but weren't accessible to indexers. Indexers can now use these functions to know when to stop paginating through splits, recurring payments, and disputes.All changes maintain consistency with the existing codebase patterns and the existing escrow_count implementation.Summary of Implementation
1. Added Three Public Getter Functions to [contract.rs]
split_count(e: Env) -> u32 (line 269-272): Returns the total number of splits created
recurring_count(e: Env) -> u32 (line 299-302): Returns the total number of recurring payments created
dispute_count(e: Env) -> u32 (line 241-244): Returns the total number of disputes created
Each function follows the same pattern as the existing escrow_count function:
Calls bump_instance to extend TTL
Reads the corresponding counter from storage using read_counter
2. Added Comprehensive Tests for each counter:
In [splitter_test.rs]
test_split_count_starts_at_zero: Verifies counter starts at 0
test_split_count_increments_on_create: Verifies counter increments correctly (tests 3 splits with IDs 1, 2, 3)
In [recurring_test.rs]
test_recurring_count_starts_at_zero: Verifies counter starts at 0
test_recurring_count_increments_on_setup: Verifies counter increments correctly (tests 3 recurring payments with IDs 1, 2, 3)
In [dispute_test.rs]
test_dispute_count_starts_at_zero: Verifies counter starts at 0
test_dispute_count_increments_on_open: Verifies counter increments correctly (tests 3 disputes with IDs 1, 2, 3)
3. Purpose:
These public getters expose the counter keys that already existed in DataKey but weren't accessible to indexers. Indexers can now use these functions to know when to stop paginating through splits, recurring payments, and disputes.All changes maintain consistency with the existing codebase patterns and the existing escrow_count implementation.

closes #182 
closes #183 
closes #184 
closes #185 