### PR TITLE
Feat/save

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -27,6 +27,7 @@ pub trait VeriTixPayTrait {
     fn place_lien(e: Env, creditor: Address, escrow_id: u32, lien_amount: i128);
     fn clear_lien(e: Env, caller: Address, escrow_id: u32);
     fn get_escrow(e: Env, escrow_id: u32) -> escrow::EscrowRecord;
+    fn is_escrow_settled(e: Env, escrow_id: u32) -> bool;
 
     // ── Disputes ──────────────────────────────────────────────────────────────
     fn get_disputes_by_claimant(e: Env, claimant: Address) -> Vec<u32>;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -47,6 +47,7 @@ pub trait VeriTixPayTrait {
     ) -> u32;
     fn execute_recurring(e: Env, recurring_id: u32);
     fn get_recurring_history(e: Env, recurring_id: u32) -> Vec<RecurringPayment>;
+    fn is_recurring_active(e: Env, recurring_id: u32) -> bool;
     fn get_escrows_batch(e: Env, escrow_ids: Vec<u32>) -> Vec<Option<escrow::EscrowRecord>>;
     fn get_escrow_age(e: Env, escrow_id: u32) -> u32;
 
@@ -171,6 +172,14 @@ impl VeriTixPayTrait for VeriTixPay {
         escrow::load_record(&e, escrow_id)
     }
 
+    fn is_escrow_settled(e: Env, escrow_id: u32) -> bool {
+        match e.storage().persistent().get::<Option<escrow::EscrowRecord>>(&DataKey::Escrow(escrow_id))
+        {
+            Some(escrow) => escrow.released || escrow.refunded,
+            None => true,
+        }
+    }
+
     fn get_disputes_by_claimant(e: Env, claimant: Address) -> Vec<u32> {
         dispute::get_disputes_by_claimant(e, claimant)
     }
@@ -205,6 +214,14 @@ impl VeriTixPayTrait for VeriTixPay {
 
     fn get_recurring_history(e: Env, recurring_id: u32) -> Vec<RecurringPayment> {
         recurring::get_recurring_history(e, recurring_id)
+    }
+
+    fn is_recurring_active(e: Env, recurring_id: u32) -> bool {
+        match e.storage().persistent().get::<Option<recurring::RecurringRecord>>(&DataKey::Recurring(recurring_id))
+        {
+            Some(record) => record.active,
+            None => false,
+        }
     }
 
     fn get_escrows_batch(e: Env, escrow_ids: Vec<u32>) -> Vec<Option<escrow::EscrowRecord>> {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -101,6 +101,7 @@ pub trait VeriTixPayTrait {
 
     // ── #454: Protocol fee stats ─────────────────────────────────────────────
     fn protocol_fee_stats(e: Env) -> (u32, Address, i128);
+    fn emergency_withdraw(e: Env, admin: Address, recipient: Address, token: Address, amount: i128);
 }
 
 #[contract]
@@ -373,5 +374,30 @@ impl VeriTixPayTrait for VeriTixPay {
             .get(&DataKey::TotalFeesCollected)
             .unwrap_or(0);
         (fee_bps, treasury, total_collected)
+    }
+
+    fn emergency_withdraw(e: Env, admin: Address, recipient: Address, token: Address, amount: i128) {
+        // Verify caller is admin and authenticated
+        admin::check_admin(&e, &admin);
+
+        // Get contract's current balance of the token
+        let token_client = soroban_sdk::token::Client::new(&e, &token);
+        let contract_balance = token_client.balance(&e.current_contract_address());
+
+        // Get total escrowed value (locked funds that cannot be touched)
+        let total_escrowed = escrow::get_escrowed_total(&e);
+
+        // Verify we're not withdrawing more than the stranded funds (contract balance - escrowed funds)
+        assert!(amount <= contract_balance - total_escrowed, "Insufficient non-escrowed funds");
+        assert!(amount > 0, "Amount must be positive");
+
+        // Transfer the amount from the contract to the recipient
+        token_client.transfer(&e.current_contract_address(), &recipient, &amount);
+
+        // Emit the emergency withdrawal event
+        e.events().publish(
+            (soroban_sdk::symbol_short!("emer_wdraw"), admin, recipient),
+            amount,
+        );
     }
 }

--- a/src/escrow_test.rs
+++ b/src/escrow_test.rs
@@ -505,6 +505,33 @@ fn test_get_escrows_batch() {
 }
 
 #[test]
+fn test_is_escrow_settled() {
+    let t = setup();
+    let expiry = t.e.ledger().sequence() + 1000;
+
+    // Non-existent escrow should return true (settled/gone)
+    assert!(t.client.is_escrow_settled(&999));
+
+    // Create a new escrow - should not be settled yet
+    let id = t.client.create_escrow(
+        &t.depositor, &t.beneficiary, &t.token, &1000, &expiry, &empty_memo(&t.e),
+    );
+    assert!(!t.client.is_escrow_settled(&id));
+
+    // Release the escrow - should now be settled
+    t.client.release_escrow(&t.depositor, &id);
+    assert!(t.client.is_escrow_settled(&id));
+
+    // Create another escrow, refund it - should be settled
+    let id2 = t.client.create_escrow(
+        &t.depositor, &t.beneficiary, &t.token, &500, &expiry, &empty_memo(&t.e),
+    );
+    assert!(!t.client.is_escrow_settled(&id2));
+    t.client.refund_escrow(&t.depositor, &id2);
+    assert!(t.client.is_escrow_settled(&id2));
+}
+
+#[test]
 fn test_get_escrow_age() {
     let t = setup();
     let start_ledger = t.e.ledger().sequence();

--- a/src/recurring_test.rs
+++ b/src/recurring_test.rs
@@ -100,3 +100,47 @@ fn test_max_executions_deactivates() {
     e.ledger().with_mut(|l| l.sequence_number = e.ledger().sequence() + interval);
     execute_recurring(&e, recurring_id);
 }
+
+#[test]
+fn test_is_recurring_active() {
+    use soroban_sdk::{Address, token};
+    use crate::contract::{VeriTixPay, VeriTixPayClient};
+
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+
+    let payer = Address::generate(&e);
+    let payee = Address::generate(&e);
+    let token = e.register_stellar_asset_contract(payer.clone());
+    let token_client = token::Client::new(&e, &token);
+    token_client.mint(&payer, &1000);
+
+    // Non-existent recurring should return false
+    assert!(!client.is_recurring_active(&999));
+
+    // Setup a new recurring payment
+    let recurring_id = client.setup_recurring(
+        &payer,
+        &payee,
+        &token,
+        &100,
+        &100, // interval
+        &3,   // max executions
+    );
+
+    // Should be active after creation
+    assert!(client.is_recurring_active(&recurring_id));
+
+    // Execute all max executions to deactivate
+    for i in 1..=3 {
+        e.ledger().with_mut(|l| l.sequence_number += 100);
+        client.execute_recurring(&recurring_id);
+    }
+
+    // Should be inactive after max executions
+    assert!(!client.is_recurring_active(&recurring_id));
+}
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,78 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, token};
+use crate::contract::{VeriTixPay, VeriTixPayClient};
 
 pub fn create_token_contract(e: &Env, admin: &Address) -> Address {
     e.register_stellar_asset_contract(admin.clone())
+}
+
+#[test]
+fn test_emergency_withdraw() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    // Setup contract and admin
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // Create token and mint some tokens
+    let token = create_token_contract(&e, &admin);
+    let token_admin_client = token::StellarAssetClient::new(&e, &token);
+    let token_client = token::Client::new(&e, &token);
+    
+    // Mint 1000 tokens directly to the contract (stranded funds)
+    token_admin_client.mint(&contract_id, &1000);
+    
+    // Create a recipient to receive the withdrawn funds
+    let recipient = Address::generate(&e);
+    
+    // Verify contract has 1000 tokens, total escrowed is 0
+    assert_eq!(token_client.balance(&contract_id), 1000);
+    assert_eq!(client.escrowed_total(), 0);
+    
+    // Withdraw the stranded funds
+    client.emergency_withdraw(&admin, &recipient, &token, &1000);
+    
+    // Verify recipient received the funds, contract has 0 left
+    assert_eq!(token_client.balance(&recipient), 1000);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+#[test]
+#[should_panic(expected = "Insufficient non-escrowed funds")]
+fn test_emergency_withdraw_cannot_touch_escrow_funds() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    // Setup contract and admin
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // Create token and mint some tokens to depositor
+    let depositor = Address::generate(&e);
+    let token = create_token_contract(&e, &depositor);
+    let token_admin_client = token::StellarAssetClient::new(&e, &token);
+    let token_client = token::Client::new(&e, &token);
+    
+    token_admin_client.mint(&depositor, &1000);
+    
+    // Create an escrow which locks 500 tokens in the contract
+    let beneficiary = Address::generate(&e);
+    let expiry = e.ledger().sequence() + 1000;
+    let id = client.create_escrow(
+        &depositor, &beneficiary, &token, &500, &expiry, &soroban_sdk::Bytes::new(&e)
+    );
+    
+    // Verify contract has 500 tokens in escrow
+    assert_eq!(token_client.balance(&contract_id), 500);
+    assert_eq!(client.escrowed_total(), 500);
+    
+    // Try to withdraw 501 tokens - should panic because only 0 non-escrowed funds exist
+    let recipient = Address::generate(&e);
+    client.emergency_withdraw(&admin, &recipient, &token, &501);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

1. **Added `is_escrow_settled` to contract.rs**:
   - Added to the trait and implemented it correctly
   - Returns `released || refunded` if the escrow exists
   - Returns `true` if the escrow doesn't exist (treated as settled/gone)

2. **Added `is_recurring_active` to contract.rs**:
   - Added to the trait and implemented it correctly
   - Returns `record.active` (the only activity-related field present in RecurringRecord) if the record exists
   - Returns `false` if the record is not found
   *Note: There is no `paused` field in the current RecurringRecord struct, so we implemented it to use the only available active flag as specified in the codebase*

closes #551

3. **Added tests for both functions**:
   - `test_is_escrow_settled` in escrow_test.rs: Tests non-existent escrow returns true, active escrow returns false, released and refunded escrows return true
   - `test_is_recurring_active` in recurring_test.rs: Tests non-existent recurring returns false, active recurring returns true, and after max executions it returns false

All files have been updated as requested:
- src/contract.rs - added both functions to the trait and implemented them
- src/escrow_test.rs - added test for is_escrow_settled
- src/recurring_test.rs - added test for is_recurring_active

closes #547

1. **Added `emergency_withdraw` function to contract.rs**:
   - Added to the contract trait and implemented it
   - Calls `admin::check_admin` which verifies the caller is the admin and requires auth
   - Gets the contract's current balance of the specified token using the token client
   - Retrieves the total escrowed value to ensure we don't touch locked funds
   - Verifies that the withdrawal amount is <= (contract balance - total escrowed value)
   - Transfers the funds from the contract to the recipient
   - Emits the required event `("emer_wdraw", admin, recipient)` with the amount

closes #549

2. **Added tests to test.rs**:
   - `test_emergency_withdraw`: Tests that stranded funds minted directly to the contract can be withdrawn successfully
   - `test_emergency_withdraw_cannot_touch_escrow_funds`: Tests that the function panics when trying to withdraw more than the available non-escrowed funds, ensuring escrowed funds are protected

All files have been updated as requested:
- src/contract.rs - added the emergency_withdraw function to the trait and implemented it
- src/test.rs - added comprehensive tests for the new functionality

Closes #546

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / Tooling

## Changelog Reminder

<!--
If this PR introduces a change that integrators or contributors should know
about (new feature, bug fix, breaking ABI change, storage layout change, new
event, new function), please add or update an entry in `CHANGELOG.md` under
the `[Unreleased]` section.

If the change is internal (refactor, test, docs-only, config-only), no
changelog entry is needed.
-->

- [ ] I have updated `CHANGELOG.md` with a description of this change.

## Checklist

- [ ] `make test` passes with no failures
- [ ] `make fmt` has been run (no formatting diffs)
- [ ] New logic has at least one test covering the happy path
- [ ] Error and edge cases are tested where practical
- [ ] `cargo clippy --all -- -D warnings` is clean
- [ ] New/updated modules include `//!` module-level docs
- [ ] `storage_types.rs` updated if new storage keys were added
- [ ] `lib.rs` updated if a new module was declared
- [ ] `docs/abi-reference.md` updated if the public interface changed
