### PR TITLE
Fix supply cap enforcement, TTL constants, memo validation, and add contract pause

### DIFF
--- a/src/balance.rs
+++ b/src/balance.rs
@@ -5,9 +5,17 @@ pub fn read_supply(e: &Env) -> i128 {
     e.storage().persistent().get(&DataKey::TotalSupply).unwrap_or(0)
 }
 
+pub fn read_max_supply(e: &Env) -> i128 {
+    e.storage().persistent().get(&DataKey::MaxSupply).unwrap_or(0)
+}
+
 pub fn increase_supply(e: &Env, amount: i128) {
     let supply = read_supply(e);
     let new_supply = supply.checked_add(amount).expect("supply overflow");
+    let max = read_max_supply(e);
+    if max > 0 && new_supply > max {
+        panic!("SupplyCap: minting would exceed max supply of {}", max);
+    }
     e.storage().persistent().set(&DataKey::TotalSupply, &new_supply);
 }
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -19,6 +19,7 @@ use crate::validation::require_positive_amount;
 
 pub trait VeriTixPayTrait {
     fn initialize(e: Env, admin: Address);
+    fn initialize_with_max_supply(e: Env, admin: Address, max_supply: i128);
 
     // ── Escrow ────────────────────────────────────────────────────────────────
     fn create_escrow(
@@ -111,6 +112,10 @@ pub trait VeriTixPayTrait {
     // ── #452: Depositor escrowed value ───────────────────────────────────────
     fn escrowed_value_for_depositor(e: Env, depositor: Address) -> i128;
 
+    // ── Pause ─────────────────────────────────────────────────────────────────
+    fn set_paused(e: Env, admin: Address, paused: bool);
+    fn is_paused(e: Env) -> bool;
+
     // ── #453: Resolver stats ─────────────────────────────────────────────────
     fn resolver_stats(e: Env, resolver: Address) -> ResolverStats;
 
@@ -181,6 +186,17 @@ impl VeriTixPayTrait for VeriTixPay {
         }
 
         env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    fn initialize_with_max_supply(env: Env, admin: Address, max_supply: i128) {
+        admin::validate_admin_address(&env, &admin);
+
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("AlreadyInitialized: contract state is locked");
+        }
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::MaxSupply, &max_supply);
     }
 
     fn create_escrow(
@@ -410,6 +426,16 @@ impl VeriTixPayTrait for VeriTixPay {
 
     fn escrowed_value_for_depositor(e: Env, depositor: Address) -> i128 {
         escrow::escrowed_value_for_depositor(&e, &depositor)
+    }
+
+    // ── Pause ─────────────────────────────────────────────────────────────────
+
+    fn set_paused(e: Env, admin: Address, paused: bool) {
+        crate::pause::set_paused(&e, &admin, paused);
+    }
+
+    fn is_paused(e: Env) -> bool {
+        e.storage().persistent().get::<_, bool>(&DataKey::Paused).unwrap_or(false)
     }
 
     // ── #453: Resolver stats ─────────────────────────────────────────────────

--- a/src/escrow.rs
+++ b/src/escrow.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{contracttype, token, Address, Bytes, Env, Vec};
-use crate::storage_types::DataKey;
+use crate::storage_types::{DataKey, MAX_MEMO_BYTES};
 
 #[contracttype]
 #[derive(Clone)]
@@ -90,8 +90,8 @@ pub fn create_escrow(
     }
 
     // #175: enforce memo length limit with the exact panic string required
-    if memo.len() > 64 {
-        panic!("MemoTooLong: memo cannot exceed 64 bytes");
+    if memo.len() > MAX_MEMO_BYTES {
+        panic!("MemoTooLong: memo cannot exceed {} bytes", MAX_MEMO_BYTES);
     }
 
     assert!(amount > 0, "amount must be greater than zero");

--- a/src/escrow_test.rs
+++ b/src/escrow_test.rs
@@ -219,6 +219,30 @@ fn test_large_memo_validation() {
     assert!(memo.len() > 64, "memo exceeds 64-byte limit");
 }
 
+#[test]
+fn test_create_escrow_panics_on_memo_too_long() {
+    let t = setup();
+    let expiry = t.e.ledger().sequence() + 1000;
+    let memo = make_memo(&t.e, &[b'x'; 65]);
+
+    // Verify that create_escrow panics when memo > MAX_MEMO_BYTES
+    use soroban_sdk::token;
+    let token_client = token::Client::new(&t.e, &t.token);
+    let contract_balance_before = token_client.balance(&t.e.current_contract_address());
+    let depositor_balance_before = token_client.balance(&t.depositor);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        t.client.create_escrow(
+            &t.depositor, &t.beneficiary, &t.token, &100, &expiry, &memo,
+        );
+    }));
+    assert!(result.is_err(), "create_escrow should panic on memo > MAX_MEMO_BYTES");
+
+    // Verify no tokens were transferred (state rollback)
+    assert_eq!(token_client.balance(&t.e.current_contract_address()), contract_balance_before);
+    assert_eq!(token_client.balance(&t.depositor), depositor_balance_before);
+}
+
 // ── #174: Partial release ─────────────────────────────────────────────────────
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod multi_escrow;
 mod multi_escrow_test;
 mod recurring;
 mod recurring_test;
+mod pause;
 mod splitter;
 mod splitter_test;
 mod storage_types;

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{Address, Env};
+use crate::storage_types::DataKey;
+
+pub fn require_not_paused(e: &Env) {
+    if e.storage().persistent().get::<_, bool>(&DataKey::Paused).unwrap_or(false) {
+        panic!("ContractPaused: contract is paused");
+    }
+}
+
+pub fn set_paused(e: &Env, caller: &Address, paused: bool) {
+    crate::admin::check_admin(e, caller);
+    e.storage().persistent().set(&DataKey::Paused, &paused);
+}

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -95,6 +95,7 @@ pub fn create_split(
 
 pub fn distribute_split(e: Env, caller: Address, split_id: u32) {
     caller.require_auth();
+    crate::pause::require_not_paused(&e);
 
     let mut record = load_record(&e, split_id);
 

--- a/src/splitter_test.rs
+++ b/src/splitter_test.rs
@@ -186,6 +186,30 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "ContractPaused")]
+    fn test_distribute_panics_when_contract_paused() {
+        let t = setup();
+        let event_ledger = t.e.ledger().sequence() + 1000;
+
+        // Create split
+        let recipients = Vec::from_array(&t.e, [(t.recipient1.clone(), 6000), (t.recipient2.clone(), 4000)]);
+        let split_id = crate::splitter::create_split(
+            t.e.clone(),
+            t.sender.clone(),
+            recipients,
+            t.token.clone(),
+            1000,
+            event_ledger,
+        );
+
+        // Pause the contract
+        crate::pause::set_paused(&t.e, &t.sender, true);
+
+        // Try to distribute while paused — should panic
+        crate::splitter::distribute_split(t.e.clone(), t.sender.clone(), split_id);
+    }
+
+    #[test]
     #[should_panic(expected = "split has been cancelled")]
     fn test_replace_split_recipient_cancelled() {
         let t = setup();

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,5 +1,20 @@
 use soroban_sdk::{contracttype, Address};
 
+// ── TTL constants ────────────────────────────────────────────────────────────
+// Balances: ~1 year (6_310_000 ledgers at ~5s/ledger)
+pub const BALANCE_LIFETIME_THRESHOLD: u32 = 6_310_000;
+// Escrow records: ~1 year
+pub const ESCROW_LIFETIME_THRESHOLD: u32 = 7_884_000;
+// Dispute records: ~6 months from opening
+pub const DISPUTE_LIFETIME_THRESHOLD: u32 = 3_942_000;
+// Recurring records: ~1 year from last execution
+pub const RECURRING_LIFETIME_THRESHOLD: u32 = 6_310_000;
+// Split records: ~90 days from creation
+pub const SPLIT_LIFETIME_THRESHOLD: u32 = 1_555_200;
+
+// ── Memo constants ───────────────────────────────────────────────────────────
+pub const MAX_MEMO_BYTES: u32 = 64;
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -29,32 +44,20 @@ pub enum DataKey {
     TotalFeesCollected,
     SplitCount,
     Split(u32),
-<<<<<<< HEAD
     PayeeRecurrings(Address),
-=======
-<<<<<<< HEAD
     MediationFeeBps,
     Holders,
     DisputeCount(u32),
     MaxDisputes(u32),
-=======
-<<<<<<< HEAD
     Version,
-=======
-<<<<<<< HEAD
     BalanceOf(Address),
     Authorized(Address),
-=======
     AllowanceSpenders(Address),
     WhitelistEnabled,
     Whitelisted(Address),
     AutoRelease(u32),
-    DisputeCount(u32),
-    MaxDisputes(u32),
->>>>>>> main
->>>>>>> main
->>>>>>> main
->>>>>>> main
+    MaxSupply,
+    Paused,
 }
 
 #[contracttype]

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{Address, Env, token};
 use crate::contract::{VeriTixPay, VeriTixPayClient};
+use crate::storage_types::DataKey;
 
 pub fn create_token_contract(e: &Env, admin: &Address) -> Address {
     e.register_stellar_asset_contract(admin.clone())
@@ -75,4 +76,83 @@ fn test_emergency_withdraw_cannot_touch_escrow_funds() {
     // Try to withdraw 501 tokens - should panic because only 0 non-escrowed funds exist
     let recipient = Address::generate(&e);
     client.emergency_withdraw(&admin, &recipient, &token, &501);
+}
+
+// ── #583: Max supply ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_max_supply_allows_minting_up_to_limit() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // Set max supply to 1000
+    e.storage().persistent().set(&DataKey::MaxSupply, &1000_i128);
+
+    // Mint 500 — should succeed (below max)
+    crate::balance::increase_supply(&e, 500);
+    assert_eq!(crate::balance::read_supply(&e), 500);
+}
+
+#[test]
+#[should_panic(expected = "SupplyCap")]
+fn test_mint_exceeding_max_supply_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // Set max supply to 1000
+    e.storage().persistent().set(&DataKey::MaxSupply, &1000_i128);
+
+    // Mint 1000 — succeeds (exactly at max)
+    crate::balance::increase_supply(&e, 1000);
+
+    // Mint 1 more — should panic
+    crate::balance::increase_supply(&e, 1);
+}
+
+#[test]
+fn test_max_supply_zero_means_unlimited() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // Ensure max supply is 0 (default — unlimited)
+    let max = crate::balance::read_max_supply(&e);
+    assert_eq!(max, 0);
+
+    // Mint a large amount — should succeed
+    crate::balance::increase_supply(&e, 1_000_000);
+    assert_eq!(crate::balance::read_supply(&e), 1_000_000);
+}
+
+// ── #583: initialize with max supply ──────────────────────────────────────────
+
+#[test]
+fn test_initialize_with_max_supply() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // Set max supply after initialization
+    e.storage().persistent().set(&DataKey::MaxSupply, &5000_i128);
+
+    assert_eq!(crate::balance::read_max_supply(&e), 5000);
+    assert_eq!(crate::balance::read_supply(&e), 0);
+
+    // Mint up to limit
+    crate::balance::increase_supply(&e, 5000);
+    assert_eq!(crate::balance::read_supply(&e), 5000);
 }


### PR DESCRIPTION
Implements four fixes for the VeriTix contract:

- **Max supply check** (Closes #583): Adds  DataKey and .  now enforces the cap; mints beyond limit panic with `SupplyCap`. Tests for mint up-to-max, exceeding max, and unlimited (max=0).
- **TTL constants** (Closes #582): Adds explicit lifetime thresholds per record type with real-time comments: `BALANCE_LIFETIME_THRESHOLD` (1yr), `ESCROW_LIFETIME_THRESHOLD` (1yr), `DISPUTE_LIFETIME_THRESHOLD` (6mo), `RECURRING_LIFETIME_THRESHOLD` (1yr), `SPLIT_LIFETIME_THRESHOLD` (90d).
- **Memo validation** (Closes #491): Adds `MAX_MEMO_BYTES` constant (64) and uses it in `create_escrow`. Added a test verifying `create_escrow` panics with memo > 64 bytes and no tokens are transferred.
- **Contract pause** (Closes #487): Adds `pause.rs` module with `require_not_paused`, `set_paused`, and `is_paused`. `distribute` now checks pause state on entry. Test confirms distribution panics when paused.