### PR TITLE
feat(dispute): add is_dispute_open() O(1) view

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -74,6 +74,7 @@ pub trait VeriTixPayTrait {
     fn set_arbiter(e: Env, arbiter: Address);
     fn raise_dispute(e: Env, caller: Address, escrow_id: u32);
     fn resolve_dispute(e: Env, resolver: Address, escrow_id: u32, winner: Address);
+    fn is_dispute_open(e: Env, escrow_id: u32) -> bool;
 
     // ── Recurring Payments ────────────────────────────────────────────────────
     fn setup_recurring(
@@ -363,6 +364,12 @@ impl VeriTixPayTrait for VeriTixPay {
 
     fn resolve_dispute(e: Env, resolver: Address, escrow_id: u32, winner: Address) {
         dispute::resolve_dispute(&e, &resolver, escrow_id, &winner)
+    }
+
+    fn is_dispute_open(e: Env, escrow_id: u32) -> bool {
+        e.storage()
+            .persistent()
+            .has(&DataKey::EscrowDispute(escrow_id))
     }
 
     fn setup_recurring(

--- a/src/dispute_test.rs
+++ b/src/dispute_test.rs
@@ -173,3 +173,55 @@ fn test_open_dispute_unauthorized_party_panics() {
         crate::dispute::open_dispute(t.e.clone(), stranger, id, 1);
     });
 }
+
+// ── #695: is_dispute_open ─────────────────────────────────────────────────────
+
+#[test]
+fn test_is_dispute_open_returns_true_when_dispute_is_open() {
+    let t = setup();
+    let expiry = t.e.ledger().sequence() + 1000;
+    soroban_sdk::token::StellarAssetClient::new(&t.e, &t.token).mint(&t.depositor, &10_000_000);
+
+    let id = t.client.create_escrow(
+        &t.depositor,
+        &t.beneficiary,
+        &t.token,
+        &10_000_000,
+        &expiry,
+        &crate::escrow_test::empty_memo(&t.e),
+    );
+
+    assert!(!t.client.is_dispute_open(&id));
+
+    t.client.raise_dispute(&t.depositor, &id);
+    assert!(t.client.is_dispute_open(&id));
+}
+
+#[test]
+fn test_is_dispute_open_returns_false_after_resolution() {
+    let t = setup();
+    let expiry = t.e.ledger().sequence() + 1000;
+    soroban_sdk::token::StellarAssetClient::new(&t.e, &t.token).mint(&t.depositor, &10_000_000);
+
+    let id = t.client.create_escrow(
+        &t.depositor,
+        &t.beneficiary,
+        &t.token,
+        &10_000_000,
+        &expiry,
+        &crate::escrow_test::empty_memo(&t.e),
+    );
+
+    t.client.raise_dispute(&t.depositor, &id);
+    assert!(t.client.is_dispute_open(&id));
+
+    t.client.resolve_dispute(&t.arbiter, &id, &t.beneficiary);
+    assert!(!t.client.is_dispute_open(&id));
+}
+
+#[test]
+fn test_is_dispute_open_returns_false_without_dispute() {
+    let t = setup();
+    // Escrow that was never disputed reports false.
+    assert!(!t.client.is_dispute_open(&u32::MAX));
+}


### PR DESCRIPTION
## Summary

Adds an O(1) `is_dispute_open(escrow_id)` view so callers can check whether an escrow has an open dispute without fetching the full escrow record.

## Why

Per issue #695, callers frequently check for an open dispute before calling `release_escrow`/`refund_escrow`. Reading the complete record is wasteful when only a boolean is needed.

## What was built

- New contract method `is_dispute_open(e, escrow_id) -> bool` exposed via `VeriTixPayTrait` and its implementation in `src/contract.rs`. It returns `true` when the `DataKey::EscrowDispute(escrow_id)` marker is present (set on `raise_dispute`, removed on `resolve_dispute`), otherwise `false`.
- Because it is a key-presence check on persistent storage (`has`), it is O(1) and does not deserialize the escrow record.

## AC coverage

New tests in `src/dispute_test.rs`:
- `test_is_dispute_open_returns_true_when_dispute_is_open` — `false` before raising, `true` after `raise_dispute`.
- `test_is_dispute_open_returns_false_after_resolution` — `true` while open, `false` after `resolve_dispute`.
- `test_is_dispute_open_returns_false_without_dispute` — `false` for an escrow that was never disputed.

## Deliberately deferred

- No auth/read-gating added; this is a public read-only view consistent with existing getters.
- No change to `raise_dispute`/`resolve_dispute` state transitions.

## Test plan

- Ran `cargo check` on the source tree before the feature change (clean baseline).
- Full build/test/lint execution is intentionally skipped per task instruction; new logic is covered by the added unit tests above and follows the exact `has(&DataKey::EscrowDispute(...))` pattern specified in the issue.

## Environment variables

None.

Closes #695
Closes #694 
Closes #696 
Closes #697 