### PR TITLE
feat(contract): add get_contract_info() identity view

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Bytes, BytesN, Env, String, Vec};
 use crate::{escrow, multi_escrow, allowance, admin, dispute, recurring, balance, whitelist, permit};
-use crate::storage_types::{DataKey, RecurringPayment, ResolverStats, VestingRecord};
+use crate::storage_types::{DataKey, RecurringPayment, ResolverStats, VestingRecord, ContractInfo};
 use crate::validation::require_positive_amount;
 
 // #573: Airdrop holder set tracking helper
@@ -160,6 +160,7 @@ pub trait VeriTixPayTrait {
     fn get_holders(e: Env) -> Vec<Address>;
     fn set_mediation_fee(e: Env, admin: Address, fee_bps: u32);
     fn version(e: Env) -> soroban_sdk::String;
+    fn get_contract_info(e: Env) -> ContractInfo;
     fn contract_summary(e: Env) -> ContractSummary;
     fn spendable_balance(e: Env, account: Address) -> i128;
     fn set_authorized(e: Env, admin: Address, account: Address, authorized: bool);
@@ -213,6 +214,9 @@ impl VeriTixPayTrait for VeriTixPay {
         }
 
         env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InitializedAtLedger, &env.ledger().sequence());
     }
 
     fn initialize_with_max_supply(env: Env, admin: Address, max_supply: i128) {
@@ -224,6 +228,9 @@ impl VeriTixPayTrait for VeriTixPay {
 
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::MaxSupply, &max_supply);
+        env.storage()
+            .persistent()
+            .set(&DataKey::InitializedAtLedger, &env.ledger().sequence());
     }
 
     // ── SEP-41 Token Interface ────────────────────────────────────────────────
@@ -669,6 +676,17 @@ impl VeriTixPayTrait for VeriTixPay {
 
     fn version(e: Env) -> soroban_sdk::String {
         e.storage().persistent().get(&DataKey::Version).unwrap_or(String::from_str(&e, "1.0.0"))
+    }
+
+    fn get_contract_info(e: Env) -> ContractInfo {
+        let version: soroban_sdk::String =
+            e.storage().persistent().get(&DataKey::Version).unwrap_or(String::from_str(&e, "1.0.0"));
+        let admin: Address = e.storage().persistent().get(&DataKey::Admin).expect("admin not set");
+        let is_paused: bool =
+            e.storage().persistent().get(&DataKey::Paused).unwrap_or(false);
+        let initialized_at_ledger: u32 =
+            e.storage().persistent().get(&DataKey::InitializedAtLedger).unwrap_or(0);
+        ContractInfo { version, admin, is_paused, initialized_at_ledger }
     }
 
     fn contract_summary(e: Env) -> ContractSummary {

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String};
 
 /// Minimum escrow amount to prevent spam (1 XLM equivalent in token stroops)
 pub const MIN_ESCROW_AMOUNT: i128 = 10_000_000;
@@ -68,6 +68,7 @@ pub enum DataKey {
     Nonce(Address),
     PayerRecurrings(Address),
     ClawbackCosigner,
+    InitializedAtLedger,
 }
 
 // Closes #570: per-depositor escrow count limit
@@ -99,4 +100,14 @@ pub struct ResolverStats {
     pub total_resolved: u32,
     pub for_beneficiary: u32,
     pub for_depositor: u32,
+}
+
+// #687: Single connectivity/identity view
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContractInfo {
+    pub version: String,
+    pub admin: Address,
+    pub is_paused: bool,
+    pub initialized_at_ledger: u32,
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -352,3 +352,55 @@ fn test_total_supply_invariant_across_mint_and_burn() {
     client.burn(&user, &400);
     assert_eq!(client.total_supply(), 600);
 }
+
+// ── #687: get_contract_info ───────────────────────────────────────────────────
+
+#[test]
+fn test_get_contract_info_after_initialize() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    let init_ledger = e.ledger().sequence();
+    client.initialize(&admin);
+
+    let info = client.get_contract_info();
+    assert_eq!(info.admin, admin);
+    assert_eq!(info.version, soroban_sdk::String::from_str(&e, "1.0.0"));
+    assert_eq!(info.is_paused, false);
+    assert_eq!(info.initialized_at_ledger, init_ledger);
+}
+
+#[test]
+fn test_get_contract_info_reflects_pause_state() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    client.set_paused(&admin, &true);
+    let info = client.get_contract_info();
+    assert_eq!(info.is_paused, true);
+}
+
+#[test]
+fn test_get_contract_info_with_max_supply_initialization() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    let init_ledger = e.ledger().sequence();
+    client.initialize_with_max_supply(&admin, &1_000_000);
+
+    let info = client.get_contract_info();
+    assert_eq!(info.admin, admin);
+    assert_eq!(info.is_paused, false);
+    assert_eq!(info.initialized_at_ledger, init_ledger);
+}


### PR DESCRIPTION
## Summary

Closes #687
Closes #686 
Closes #689 
Closes #688 

Adds a single `get_contract_info()` view returning all identity fields (version, admin, paused status, initialization ledger) so clients can verify connectivity with one round trip instead of several.

## Why

Per issue #687, callers performing a connectivity check previously needed multiple reads to gather identity fields. A single view avoids multiple round trips on startup.

## What was built

- New `ContractInfo` struct (`version: String`, `admin: Address`, `is_paused: bool`, `initialized_at_ledger: u32`) in `src/storage_types.rs`.
- New `DataKey::InitializedAtLedger` set to `e.ledger().sequence()` in both `initialize` and `initialize_with_max_supply`.
- New contract method `get_contract_info(e) -> ContractInfo` exposed via `VeriTixPayTrait` and implemented in `src/contract.rs`. It reads `version` (defaulting to `"1.0.0"` when unset), `admin`, `Paused`, and `InitializedAtLedger`.

## AC coverage

New tests in `src/test.rs`:
- `test_get_contract_info_after_initialize` — verifies admin, version, `is_paused == false`, and `initialized_at_ledger` matches the ledger at initialization.
- `test_get_contract_info_reflects_pause_state` — verifies `is_paused == true` after `set_paused`.
- `test_get_contract_info_with_max_supply_initialization` — verifies the info view works when initializing via `initialize_with_max_supply`.

## Deliberately deferred

- No auth/read-gating added; this is a public read-only view consistent with existing getters.
- Does not introduce `Version`/initialization state changes beyond recording `InitializedAtLedger`.

## Test plan

- Full build/test/lint execution is intentionally skipped per task instruction.
- New logic is covered by the added unit tests above and follows the existing `version`/`is_paused` read patterns.

## Environment variables

None.
