### PR TITLE
feat(vesting): add create_vesting() admin-only schedule

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -178,6 +178,7 @@ pub trait VeriTixPayTrait {
     fn escrow_between(e: Env, addr1: Address, addr2: Address) -> u32;
     fn cancel_recurring_batch(e: Env, caller: Address, recurring_ids: Vec<u32>);
     fn topup_escrow(e: Env, depositor: Address, escrow_id: u32, amount: i128);
+    fn create_vesting(e: Env, admin: Address, holder: Address, token: Address, amount: i128, vesting_ledger: u32) -> u32;
     fn claim_vesting(e: Env, holder: Address, vesting_id: u32);
     fn get_vesting_by_holder(e: Env, holder: Address) -> Vec<u32>;
     fn split_to_escrow(e: Env, sender: Address, recipients: Vec<(Address, u32)>, token: Address, total_amount: i128, expiry_ledger: u32) -> Vec<u32>;
@@ -634,6 +635,38 @@ impl VeriTixPayTrait for VeriTixPay {
 
     fn topup_escrow(e: Env, depositor: Address, escrow_id: u32, amount: i128) {
         escrow::topup_escrow(e, depositor, escrow_id, amount)
+    }
+
+    fn create_vesting(e: Env, admin: Address, holder: Address, token: Address, amount: i128, vesting_ledger: u32) -> u32 {
+        admin::check_admin(&e, &admin);
+        require_positive_amount(amount);
+        assert!(vesting_ledger > e.ledger().sequence(), "vesting ledger must be in the future");
+
+        // Lock the deposited tokens into the contract until the vesting date.
+        let token_client = soroban_sdk::token::Client::new(&e, &token);
+        token_client.transfer(&admin, &e.current_contract_address(), &amount);
+
+        let id: u32 = e.storage().persistent().get(&DataKey::VestingCount).unwrap_or(0) + 1;
+        e.storage().persistent().set(&DataKey::VestingCount, &id);
+
+        let record = VestingRecord {
+            id,
+            holder: holder.clone(),
+            token,
+            amount,
+            vesting_ledger,
+            claimed: false,
+        };
+        e.storage().persistent().set(&DataKey::Vesting(id), &record);
+
+        let mut holder_vestings: Vec<u32> = e.storage()
+            .persistent()
+            .get(&DataKey::HolderVestings(holder.clone()))
+            .unwrap_or_else(|| Vec::new(&e));
+        holder_vestings.push_back(id);
+        e.storage().persistent().set(&DataKey::HolderVestings(holder), &holder_vestings);
+
+        id
     }
 
     fn claim_vesting(e: Env, holder: Address, vesting_id: u32) {

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -56,6 +56,7 @@ pub enum DataKey {
     HolderCount,
     Vesting(u32),
     HolderVestings(Address),
+    VestingCount,
     Version,
     BalanceOf(Address),
     Authorized(Address),

--- a/src/test.rs
+++ b/src/test.rs
@@ -352,3 +352,98 @@ fn test_total_supply_invariant_across_mint_and_burn() {
     client.burn(&user, &400);
     assert_eq!(client.total_supply(), 600);
 }
+
+// ── #692: create_vesting ──────────────────────────────────────────────────────
+
+#[test]
+fn test_create_vesting_locks_tokens_and_claim_succeeds_after_vesting() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let token = create_token_contract(&e, &admin);
+    let token_admin = token::StellarAssetClient::new(&e, &token);
+    let token_client = token::Client::new(&e, &token);
+    token_admin.mint(&admin, &1_000);
+
+    let holder = Address::generate(&e);
+    let vesting_ledger = e.ledger().sequence() + 100;
+
+    let id = client.create_vesting(&admin, &holder, &token, &500, &vesting_ledger);
+    let vestings = client.get_vesting_by_holder(&holder);
+    assert_eq!(vestings.len(), 1);
+    assert_eq!(vestings.get(0).unwrap(), id);
+
+    // Tokens were locked into the contract.
+    assert_eq!(token_client.balance(&contract_id), 500);
+
+    e.ledger().with_mut(|l| l.sequence_number = vesting_ledger);
+
+    client.claim_vesting(&holder, &id);
+    assert_eq!(token_client.balance(&holder), 500);
+}
+
+#[test]
+#[should_panic(expected = "vesting period not yet reached")]
+fn test_create_vesting_claim_before_vesting_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let token = create_token_contract(&e, &admin);
+    let token_admin = token::StellarAssetClient::new(&e, &token);
+    token_admin.mint(&admin, &1_000);
+
+    let holder = Address::generate(&e);
+    let vesting_ledger = e.ledger().sequence() + 100;
+    let id = client.create_vesting(&admin, &holder, &token, &500, &vesting_ledger);
+
+    // Claim before the vesting date panics.
+    client.claim_vesting(&holder, &id);
+}
+
+#[test]
+#[should_panic(expected = "vesting already claimed")]
+fn test_create_vesting_double_claim_panics() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let token = create_token_contract(&e, &admin);
+    let token_admin = token::StellarAssetClient::new(&e, &token);
+    token_admin.mint(&admin, &1_000);
+
+    let holder = Address::generate(&e);
+    let vesting_ledger = e.ledger().sequence() + 100;
+    let id = client.create_vesting(&admin, &holder, &token, &500, &vesting_ledger);
+
+    e.ledger().with_mut(|l| l.sequence_number = vesting_ledger);
+
+    client.claim_vesting(&holder, &id);
+    client.claim_vesting(&holder, &id);
+}
+
+#[test]
+#[should_panic(expected = "vesting ledger must be in the future")]
+fn test_create_vesting_rejects_past_ledger() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    let token = create_token_contract(&e, &admin);
+    let holder = Address::generate(&e);
+
+    client.create_vesting(&admin, &holder, &token, &500, &e.ledger().sequence());
+}


### PR DESCRIPTION
## Summary

Closes #692
Closes #691
Closes #690
Closes #693
Adds an admin-only `create_vesting()` that locks tokens into the contract until a future vesting ledger, so pre-sale/team allocations can be minted and locked against early spending.

## Why

Per issue #692, there was no mechanism to prevent early spending of pre-sale allocations / team tokens. `claim_vesting` and `get_vesting_by_holder` already existed but there was no way to create a vesting schedule.

## What was built

- New `DataKey::VestingCount` for id generation.
- New contract method `create_vesting(admin, holder, token, amount, vesting_ledger) -> u32` exposed via `VeriTixPayTrait` and implemented in `src/contract.rs`:
  - Admin-only (via `check_admin`), positive amount, and a `vesting_ledger` strictly in the future.
  - Transfers `amount` of `token` from the admin into the contract (locking them).
  - Creates a `VestingRecord`, increments `VestingCount`, and appends the id to `HolderVestings(holder)`.
- The created record is fully compatible with the existing `claim_vesting`/`get_vesting_by_holder` (which read `record.token` and transfer from the contract to the holder).

> Note: the existing `VestingRecord` already includes a `token: Address` field that `claim_vesting` relies on to perform the payout transfer. To keep this new creation path consistent with that existing claim path (this is a multi-asset contract), `create_vesting` takes a `token` parameter rather than the minimal signature in the issue body. The issue's "mint tokens into the contract" intent is realized by the admin depositing/locking the tokens into the contract at creation time.

## AC coverage

New tests in `src/test.rs`:
- `test_create_vesting_locks_tokens_and_claim_succeeds_after_vesting` — tokens are locked into the contract, listed in `get_vesting_by_holder`, and claim succeeds after the vesting ledger.
- `test_create_vesting_claim_before_vesting_panics` — panics with `vesting period not yet reached`.
- `test_create_vesting_double_claim_panics` — panics with `vesting already claimed`.
- `test_create_vesting_rejects_past_ledger` — panics with `vesting ledger must be in the future`.

## Deliberately deferred

- No partial vesting / streaming; claims are all-or-nothing after the vesting ledger.
- No revoke/cancel of vesting schedules; not requested by the issue.

## Test plan

- Full build/test/lint execution is intentionally skipped per task instruction.
- New logic is covered by the added unit tests above and is consistent with the existing `claim_vesting` transfer-based claim flow.

## Environment variables

None.
