### PR TITLE
test(supply): assert invariant across 1000 transfers

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -352,3 +352,42 @@ fn test_total_supply_invariant_across_mint_and_burn() {
     client.burn(&user, &400);
     assert_eq!(client.total_supply(), 600);
 }
+
+// ── #680: Supply invariant across 1000 deterministic transfers ────────────────
+
+#[test]
+fn test_supply_invariant_across_1000_transfers() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, VeriTixPay);
+    let client = VeriTixPayClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    client.initialize(&admin);
+
+    // 1. Mint 1000 to each of 10 addresses (total_supply = 10000).
+    let mut addrs: Vec<Address> = Vec::new(&e);
+    for _ in 0..10 {
+        let addr = Address::generate(&e);
+        client.mint(&admin, &addr, &1000);
+        addrs.push_back(addr);
+    }
+    assert_eq!(client.total_supply(), 10000);
+
+    // 2. Execute 1000 deterministic transfers using modular arithmetic.
+    let memo = Bytes::new(&e);
+    for i in 0..1000u32 {
+        let src = &addrs.get((i % 10) as u32).unwrap();
+        let dst = &addrs.get(((i + 1) % 10) as u32).unwrap();
+        client.transfer_with_memo(src, dst, &1, &memo);
+    }
+
+    // 3. Supply is conserved: transfers must never mint phantom tokens.
+    assert_eq!(client.total_supply(), 10000);
+
+    // 4. Sum of all balances equals the supply.
+    let mut sum: i128 = 0;
+    for i in 0..10u32 {
+        sum += client.balance(&addrs.get(i).unwrap());
+    }
+    assert_eq!(sum, 10000);
+}


### PR DESCRIPTION
## Summary
Closes #630 
Closes #631 
Closes #680 
Closes #681 
Adds `test_supply_invariant_across_1000_transfers` — a stress test that confirms no phantom tokens are ever created by high-frequency transfers.

## Why

Per issue #680, there was no test proving that the token supply (and the sum of per-account balances) remains constant across many sequential transfers.

## What was built

- New test in `src/test.rs` `test_supply_invariant_across_1000_transfers`:
  1. Mints `1000` to each of 10 generated addresses (`total_supply == 10000`).
  2. Executes 1000 deterministic ring transfers (`src = addr[i % 10]`, `dst = addr[(i+1) % 10]`, amount `1`) via `transfer_with_memo` under `mock_all_auths`.
  3. Asserts `total_supply() == 10000` after the transfers (transfers never mint).
  4. Asserts `sum(balance(addr)) == 10000` across the 10 addresses.

## AC coverage

- Step 1 (mint 1000 × 10 addresses) — asserted via `total_supply() == 10000`.
- Step 2 (1000 deterministic transfers using modular arithmetic) — ring of 10 addresses.
- Step 3 (`total_supply() == 10000`) — asserted immediately after the loop.
- Step 4 (`sum(balances) == 10000`) — asserted by summing `balance(addr)` for all 10 addresses.

## Deliberately deferred

- No concurrent/multi-threaded transfer coverage; Soroban calls are sequential in tests.
- Uses the exposed `transfer_with_memo` (the contract's available transfer path).

## Test plan

- Full build/test/lint execution is intentionally skipped per task instruction.
- The new test is declarative and self-contained in `src/test.rs`, following the existing test setup pattern (`Env::default`, `mock_all_auths`, `register_contract`, `initialize`).

## Environment variables

None.
