### PR TITLE
test(integration): complete soroban-cli localnet integration script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: e2e-test smoke-test integration-test
+.PHONY: build e2e-test smoke-test integration-test
+
+build:
+	$(MAKE) -C veritixpay/contract/token build
 
 e2e-test:
 	@echo "Running end-to-end event lifecycle test..."

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -1,79 +1,137 @@
 #!/usr/bin/env bash
+# VeriTix Soroban CLI integration test against localnet (#682).
+#
+# Deploys the compiled WASM and verifies core operations through the full
+# Soroban execution stack, printing PASS/FAIL with the tx hash per step.
+#
+# Requirements:
+#   - `soroban` CLI installed (https://soroban.stellar.org/docs/reference/soroban-cli)
+#   - A localnet (standalone quickstart) reachable at RPC_URL
+#   - The contract WASM must exist in target/wasm32v1-none/release/
 set -euo pipefail
+
+# --- Configuration (overridable via environment) ---
+RPC_URL="${RPC_URL:-http://localhost:8000/soroban/rpc}"
+NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
+ACCOUNT="${STELLAR_ACCOUNT:-integration-test}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WASM="$ROOT/target/wasm32v1-none/release/veritixpay.wasm"
+
+# MIN_ESCROW_AMOUNT from src/storage_types.rs. Keep in sync if it changes.
+MIN_ESCROW_AMOUNT=10000000
 
 PASS=0
 FAIL=0
 
-pass() {
-  echo "PASS: $1"
-  PASS=$((PASS + 1))
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+soroban_args() {
+  echo "--rpc-url $RPC_URL --network-passphrase $NETWORK_PASSPHRASE --source-account $ACCOUNT"
 }
 
-fail() {
-  echo "FAIL: $1"
-  FAIL=$((FAIL + 1))
+# Run a soroban invocation and print the tx hash alongside the result.
+invoke() {
+  local hash
+  hash=$(soroban contract invoke $(soroban_args) "$@" --json 2>&1) || {
+    echo "$hash"
+    return 1
+  }
+  # Best-effort tx hash extraction from the JSON tx meta.
+  local tx_hash
+  tx_hash=$(echo "$hash" | grep -oE '"hash":"[A-Za-z0-9]+' | head -1 | cut -d'"' -f4)
+  [ -n "$tx_hash" ] && echo "tx=$tx_hash"
+  echo "$hash"
+  return 0
 }
 
-echo "=== VeriTix Contract Integration Test ==="
+echo "=== VeriTix Contract Integration Test (localnet) ==="
 echo ""
 
-# 1. Deploy the contract
-echo "--- Step 1: Deploy contract ---"
-WASM=$(ls target/wasm32v1-none/release/*.wasm 2>/dev/null | head -1)
-if [ -z "$WASM" ]; then
-  fail "No WASM file found. Run 'make build' first."
+# --- Step 1: Build WASM ---
+echo "--- Step 1: Build WASM ---"
+if make -C "$ROOT/veritixpay/contract/token" build >/dev/null 2>&1; then
+  pass "make build produced WASM"
 else
-  CONTRACT_ID=$(soroban contract deploy --wasm "$WASM" 2>&1) && pass "Contract deployed: $CONTRACT_ID" || fail "Deploy failed: $CONTRACT_ID"
+  fail "make build failed; WASM not produced"
 fi
 
-# 2. Initialize the contract
-echo "--- Step 2: Initialize contract ---"
-ADMIN="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
-if soroban contract invoke --id "$CONTRACT_ID" -- initialize --admin "$ADMIN" 2>&1; then
+WASM=$(ls "$ROOT"/target/wasm32v1-none/release/*.wasm 2>/dev/null | head -1)
+[ -z "$WASM" ] && fail "No WASM found at target/wasm32v1-none/release/" || pass "WASM found: $WASM"
+
+# --- Prepare a funded source account (valid addresses instead of hardcoded fakes) ---
+if ! soroban keys address "$ACCOUNT" >/dev/null 2>&1; then
+  soroban keys generate "$ACCOUNT" --rpc-url "$RPC_URL" \
+    --network-passphrase "$NETWORK_PASSPHRASE" --fund >/dev/null
+fi
+ADMIN=$(soroban keys address "$ACCOUNT")
+SECOND=$(soroban keys generate "${ACCOUNT}-2" --rpc-url "$RPC_URL" \
+  --network-passphrase "$NETWORK_PASSPHRASE" --fund --overwrite >/dev/null 2>&1 && soroban keys address "${ACCOUNT}-2")
+
+# --- Step 2: Deploy ---
+echo "--- Step 2: Deploy contract ---"
+CONTRACT_ID=$(soroban contract deploy $(soroban_args) --wasm "$WASM")
+if [ -n "$CONTRACT_ID" ]; then
+  pass "Contract deployed: $CONTRACT_ID"
+else
+  fail "Contract deployment failed"
+fi
+
+# --- Step 3: Initialize ---
+echo "--- Step 3: Initialize contract ---"
+if invoke --id "$CONTRACT_ID" -- initialize --admin "$ADMIN" \
+    --name VeriTix --symbol VTX --decimal 7; then
   pass "Contract initialized"
 else
   fail "Initialization failed"
 fi
 
-# 3. Mint tokens
-echo "--- Step 3: Mint tokens ---"
-USER="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ"
-if soroban contract invoke --id "$CONTRACT_ID" -- mint --admin "$ADMIN" --to "$USER" --amount 1000 2>&1; then
+# --- Step 4: Mint 1000 ---
+echo "--- Step 4: Mint 1000 tokens ---"
+if invoke --id "$CONTRACT_ID" -- mint --admin "$ADMIN" --to "$ADMIN" --amount 1000; then
   pass "Minted 1000 tokens"
 else
   fail "Mint failed"
 fi
 
-# 4. Check balance
-echo "--- Step 4: Check balance ---"
-BALANCE=$(soroban contract invoke --id "$CONTRACT_ID" -- balance --account "$USER" 2>&1)
-if echo "$BALANCE" | grep -q "1000"; then
+# --- Step 5: Balance = 1000 ---
+echo "--- Step 5: Check balance ---"
+BALANCE=$(soroban contract invoke $(soroban_args) --id "$CONTRACT_ID" -- balance --id "$ADMIN")
+if [ "$BALANCE" = "1000" ]; then
   pass "Balance is 1000"
 else
   fail "Expected balance 1000, got: $BALANCE"
 fi
 
-# 5. Transfer tokens
-echo "--- Step 5: Transfer tokens ---"
-RECIPIENT="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ2"
-MEMO="00"
-if soroban contract invoke --id "$CONTRACT_ID" -- transfer_with_memo --from "$USER" --to "$RECIPIENT" --amount 100 --memo "$MEMO" 2>&1; then
+# --- Step 6: Transfer 100 ---
+echo "--- Step 6: Transfer 100 tokens ---"
+if invoke --id "$CONTRACT_ID" -- transfer_with_memo \
+    --from "$ADMIN" --to "$SECOND" --amount 100 --memo "00"; then
   pass "Transferred 100 tokens"
 else
   fail "Transfer failed"
 fi
 
-# 6. Create escrow
-echo "--- Step 6: Create escrow ---"
-BENEFICIARY="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQ3"
-EXPIRY=$(( $(soroban ledger sequence 2>/dev/null || echo 1000) + 1000 ))
-if soroban contract invoke --id "$CONTRACT_ID" -- create_escrow --depositor "$USER" --beneficiary "$BENEFICIARY" --token "$USER" --amount 500 --expiry_ledger "$EXPIRY" --memo "00" 2>&1; then
-  pass "Escrow created"
+# --- Step 7: Create escrow ---
+echo "--- Step 7: Create escrow ---"
+# Top up the depositor so the escrow amount clears MIN_ESCROW_AMOUNT.
+if invoke --id "$CONTRACT_ID" -- mint --admin "$ADMIN" --to "$ADMIN" \
+    --amount "$MIN_ESCROW_AMOUNT"; then
+  EXPIRY=$(( $(soroban ledger sequence --rpc-url "$RPC_URL" \
+      --network-passphrase "$NETWORK_PASSPHRASE" 2>/dev/null || echo 1000) + 1000 ))
+  ESCROW_ID=$(soroban contract invoke $(soroban_args) --id "$CONTRACT_ID" -- create_escrow \
+      --depositor "$ADMIN" --beneficiary "$SECOND" --token "$CONTRACT_ID" \
+      --amount "$MIN_ESCROW_AMOUNT" --expiry_ledger "$EXPIRY" --memo "00")
+  if [ -n "$ESCROW_ID" ] && [ "$ESCROW_ID" != "0" ]; then
+    pass "Escrow created with id: $ESCROW_ID"
+  else
+    fail "Escrow creation returned no id"
+  fi
 else
-  fail "Escrow creation failed"
+  fail "Escrow funding mint failed"
 fi
 
-# Summary
+# --- Summary ---
 echo ""
 echo "=== Results ==="
 echo "PASS: $PASS"


### PR DESCRIPTION
# Summary
Closes #685 
Closes #682 
Closes #683 
Closes #684 

Completes `scripts/integration_test.sh` as a full Soroban-CLI integration test that deploys the compiled WASM and verifies core operations through the entire Soroban execution stack against a localnet, printing `PASS`/`FAIL` with the tx hash per step. Also adds a `make build` target to the root `Makefile`.

## Changes

### `scripts/integration_test.sh` (rewritten / completed)
Follows the issue's full step list:
1. **Build WASM** — runs `make build` (new root target delegates to the token contract build).
2. **Deploy** — `soroban contract deploy --wasm ...`.
3. **Initialize** — `initialize --admin ... --name VeriTix --symbol VTX --decimal 7`.
4. **Mint 1000** to the admin account.
5. **Balance** — asserts the balance is exactly `1000`.
6. **Transfer 100** to a second account via `transfer_with_memo`.
7. **Create escrow** — `create_escrow ... --token "<contract id>"` and asserts a returned escrow id.
8. **PASS/FAIL per step** with a best-effort tx hash printed on each invoke.
9. Prints a final `PASS`/`FAIL` summary and exits non-zero on failure.

### `Makefile`
- Added a `build` target (`make -C veritixpay/contract/token build`) so step 1 of the issue works.
- `make integration-test` target already existed and still invokes `scripts/integration_test.sh`.

## Fixes over the original incomplete script

- Added the missing **Build WASM** step.
- Replaced the hardcoded, invalid `GAAAA...` fake addresses with real funded localnet accounts via `soroban keys generate --fund`, so invocations authenticate correctly.
- Added the required `--rpc-url` / `--network-passphrase` / `--source-account` flags on every `soroban` call.
- Corrected `create_escrow` to pass the contract's own address as `--token` (instead of the depositor's address).
- Sized the escrow amount to clear `MIN_ESCROW_AMOUNT` (10,000,000) and topped up the depositor, since `create_escrow` requires an amount of at least 10M per the contract invariant (a documented deviation from a literal "500" amount, required for the step to succeed).
- Prints the tx hash with each step's result.

## Test plan

- Script validated with `bash -n` (syntax OK).
- `make -n build` confirmed the build target delegates correctly.
- Full execution of the integration test (which would require a running localnet) is intentionally skipped per task instruction.

## Environment variables

- `RPC_URL` (default `http://localhost:8000/soroban/rpc`)
- `NETWORK_PASSPHRASE` (default `Standalone Network ; February 2017`)
- `STELLAR_ACCOUNT` (default `integration-test`)
