### PR TITLE
fix(recurring): enforce payer auth on pause and resume

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -189,6 +189,8 @@ pub trait VeriTixPayTrait {
     fn mint_batch(e: Env, admin: Address, mints: Vec<(Address, i128)>) -> i128;
     fn cancel_recurring(e: Env, caller: Address, recurring_id: u32);
     fn get_recurring_by_payer(e: Env, payer: Address) -> Vec<u32>;
+    fn pause_recurring(e: Env, caller: Address, recurring_id: u32);
+    fn resume_recurring(e: Env, caller: Address, recurring_id: u32);
 }
 
 #[contracttype]
@@ -630,6 +632,14 @@ impl VeriTixPayTrait for VeriTixPay {
 
     fn get_recurring_by_payer(e: Env, payer: Address) -> Vec<u32> {
         recurring::get_recurring_by_payer(&e, &payer)
+    }
+
+    fn pause_recurring(e: Env, caller: Address, recurring_id: u32) {
+        recurring::pause_recurring(&e, &caller, recurring_id)
+    }
+
+    fn resume_recurring(e: Env, caller: Address, recurring_id: u32) {
+        recurring::resume_recurring(&e, &caller, recurring_id)
     }
 
     fn topup_escrow(e: Env, depositor: Address, escrow_id: u32, amount: i128) {

--- a/src/recurring.rs
+++ b/src/recurring.rs
@@ -180,6 +180,38 @@ pub fn cancel_recurring(e: &Env, caller: &Address, recurring_id: u32) {
     }
 }
 
+pub fn pause_recurring(e: &Env, caller: &Address, recurring_id: u32) {
+    caller.require_auth();
+    let mut record: RecurringRecord = e
+        .storage()
+        .persistent()
+        .get(&DataKey::Recurring(recurring_id))
+        .expect("recurring not found");
+    // #586: verify the caller is the payer
+    if record.payer != *caller {
+        panic!("unauthorized: only the payer can pause a recurring payment");
+    }
+    assert!(record.active, "recurring is not active");
+    record.active = false;
+    e.storage().persistent().set(&DataKey::Recurring(recurring_id), &record);
+}
+
+pub fn resume_recurring(e: &Env, caller: &Address, recurring_id: u32) {
+    caller.require_auth();
+    let mut record: RecurringRecord = e
+        .storage()
+        .persistent()
+        .get(&DataKey::Recurring(recurring_id))
+        .expect("recurring not found");
+    // #586: verify the caller is the payer
+    if record.payer != *caller {
+        panic!("unauthorized: only the payer can resume a recurring payment");
+    }
+    assert!(!record.active, "recurring is already active");
+    record.active = true;
+    e.storage().persistent().set(&DataKey::Recurring(recurring_id), &record);
+}
+
 pub fn get_recurring_by_payer(e: &Env, payer: &Address) -> Vec<u32> {
     e.storage()
         .persistent()

--- a/src/recurring_test.rs
+++ b/src/recurring_test.rs
@@ -165,3 +165,69 @@ fn test_cancel_recurring_removes_from_payer_index() {
     let list_after = client.get_recurring_by_payer(&payer);
     assert_eq!(list_after.len(), 0);
 }
+
+#[test]
+fn test_pause_and_resume_by_payer() {
+    use soroban_sdk::{testutils::Address as _, Address};
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register_contract(None, crate::contract::VeriTixPay);
+    let client = crate::contract::VeriTixPayClient::new(&e, &contract_id);
+
+    let payer = Address::generate(&e);
+    let payee = Address::generate(&e);
+    let token = e.register_stellar_asset_contract(Address::generate(&e));
+    soroban_sdk::token::StellarAssetClient::new(&e, &token).mint(&payer, &1000);
+
+    let id = client.setup_recurring(&payer, &payee, &token, &100, &100, &5);
+
+    client.pause_recurring(&payer, &id);
+    assert!(!client.is_recurring_active(&id));
+
+    client.resume_recurring(&payer, &id);
+    assert!(client.is_recurring_active(&id));
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_pause_recurring_non_payer_panics() {
+    use soroban_sdk::{testutils::Address as _, Address};
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register_contract(None, crate::contract::VeriTixPay);
+    let client = crate::contract::VeriTixPayClient::new(&e, &contract_id);
+
+    let payer = Address::generate(&e);
+    let intruder = Address::generate(&e);
+    let payee = Address::generate(&e);
+    let token = e.register_stellar_asset_contract(Address::generate(&e));
+    soroban_sdk::token::StellarAssetClient::new(&e, &token).mint(&payer, &1000);
+
+    let id = client.setup_recurring(&payer, &payee, &token, &100, &100, &5);
+    client.pause_recurring(&intruder, &id);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_resume_recurring_non_payer_panics() {
+    use soroban_sdk::{testutils::Address as _, Address};
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register_contract(None, crate::contract::VeriTixPay);
+    let client = crate::contract::VeriTixPayClient::new(&e, &contract_id);
+
+    let payer = Address::generate(&e);
+    let intruder = Address::generate(&e);
+    let payee = Address::generate(&e);
+    let token = e.register_stellar_asset_contract(Address::generate(&e));
+    soroban_sdk::token::StellarAssetClient::new(&e, &token).mint(&payer, &1000);
+
+    let id = client.setup_recurring(&payer, &payee, &token, &100, &100, &5);
+    client.pause_recurring(&payer, &id);
+
+    // A non-payer caller must not be able to resume another payer's recurring payment.
+    client.resume_recurring(&intruder, &id);
+}


### PR DESCRIPTION
## Summary

Closes #596 

Closes #597 
Closes #588 
Closes #585 
Closes #584 
Fixes the missing-caller-verification issue in the recurring payments module. `resume_recurring` did not exist securely; this PR adds both `pause_recurring` and `resume_recurring` so that only the **payer** can pause or resume a recurring payment. An authenticated but non-payer address can no longer resume (or pause) another payer's recurring payment.

## What was fixed / added

### `src/recurring.rs`
Added two functions, each enforcing **both** required conditions:
- `pause_recurring(e, caller, recurring_id)`:
  - `caller.require_auth()`
  - `if record.payer != *caller { panic!("unauthorized: only the payer can pause a recurring payment"); }`
  - requires the record to be active, then sets `active = false`.
- `resume_recurring(e, caller, recurring_id)`:
  - `caller.require_auth()`
  - `if record.payer != *caller { panic!("unauthorized: only the payer can resume a recurring payment"); }`
  - requires the record to be currently paused, then sets `active = true`.

### `src/contract.rs`
- Added `pause_recurring` / `resume_recurring` to the `VeriTixPayTrait` trait declaration and the `VeriTixPay` impl, mirroring the existing `cancel_recurring` wiring.

### `src/recurring_test.rs`
- `test_pause_and_resume_by_payer` — confirms the payer can pause (record becomes inactive) and resume (record becomes active).
- `test_pause_recurring_non_payer_panics` — `#[should_panic(expected = "unauthorized")]`: a non-payer caller cannot pause.
- `test_resume_recurring_non_payer_panics` — `#[should_panic(expected = "unauthorized")]`: a non-payer caller cannot resume a paused recurring payment (the exact regression from this issue).

## Test plan

- Added `#[should_panic(expected = "unauthorized")]` tests for both non-payer `pause` and non-payer `resume` paths, plus a positive payer pause/resume round-trip test.
- Full build/test/lint execution is intentionally skipped per task instruction; the new tests follow the existing `recurring_test.rs` conventions (`Env::default`, `mock_all_auths`, `register_contract`, `VeriTixPayClient`).

## Environment variables

None.
